### PR TITLE
vga_sprites: add Verilog mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,11 @@ jobs:
                 done
                 vcell=""
                 verilog_cell=""
-                [ -n "$vhdl" ]    && vcell="![${vhdl}](${base}/${vhdl})"
-                [ -n "$verilog" ] && verilog_cell="![${verilog}](${base}/${verilog})"
+                # Fixed-width <img> instead of ![alt](url) so a project
+                # whose Verilog netlist synthesises wider than its VHDL
+                # twin (or vice versa) doesn't blow out the table column.
+                [ -n "$vhdl" ]    && vcell="<img src=\"${base}/${vhdl}\" alt=\"${vhdl}\" width=\"480\">"
+                [ -n "$verilog" ] && verilog_cell="<img src=\"${base}/${verilog}\" alt=\"${verilog}\" width=\"480\">"
                 echo "| \`${stem}\` | ${vcell} | ${verilog_cell} |" >> "$summary"
               done
             done
@@ -353,8 +356,10 @@ jobs:
                     [ -z "$verilog" ] && [ -f "$d/${stem}_v.${ext}" ] && verilog="${stem}_v.${ext}"
                   done
                   vcell=""; verilog_cell=""
-                  [ -n "$vhdl" ]    && vcell="![${vhdl}](${base}/${proj}/${vhdl})"
-                  [ -n "$verilog" ] && verilog_cell="![${verilog}](${base}/${proj}/${verilog})"
+                  # Fixed-width <img> — see the rationale in the
+                  # per-project summary step above.
+                  [ -n "$vhdl" ]    && vcell="<img src=\"${base}/${proj}/${vhdl}\" alt=\"${vhdl}\" width=\"480\">"
+                  [ -n "$verilog" ] && verilog_cell="<img src=\"${base}/${proj}/${verilog}\" alt=\"${verilog}\" width=\"480\">"
                   echo "| \`${stem}\` | ${vcell} | ${verilog_cell} |"
                 done
               done

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ and Verilog on the right so you can compare the two directly.
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `blink_led` (netlist) | ![blink_led netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/blink_led.svg) | ![blink_led netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/blink_led_v.svg) |
-| `tb_blink_led` | ![blink_led waveform (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/tb_blink_led.png) | ![blink_led waveform (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/tb_blink_led_v.png) |
+| `blink_led` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/blink_led.svg" alt="blink_led netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/blink_led_v.svg" alt="blink_led netlist (Verilog)" width="480"> |
+| `tb_blink_led` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/tb_blink_led.png" alt="blink_led waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/blink_led/tb_blink_led_v.png" alt="blink_led waveform (Verilog)" width="480"> |
 
 </details>
 
@@ -89,8 +89,8 @@ and Verilog on the right so you can compare the two directly.
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `pwm_led` (netlist) | ![pwm_led netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/pwm_led.svg) | ![pwm_led netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/pwm_led_v.svg) |
-| `tb_pwm_led` | ![pwm_led waveform (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/tb_pwm_led.png) | ![pwm_led waveform (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/tb_pwm_led_v.png) |
+| `pwm_led` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/pwm_led.svg" alt="pwm_led netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/pwm_led_v.svg" alt="pwm_led netlist (Verilog)" width="480"> |
+| `tb_pwm_led` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/tb_pwm_led.png" alt="pwm_led waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/pwm_led/tb_pwm_led_v.png" alt="pwm_led waveform (Verilog)" width="480"> |
 
 </details>
 
@@ -99,8 +99,8 @@ and Verilog on the right so you can compare the two directly.
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `uart_tx` (netlist) | ![uart_tx netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/uart_tx.svg) | ![uart_tx netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/uart_tx_v.svg) |
-| `tb_uart_tx` | ![uart_tx waveform (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/tb_uart_tx.png) | ![uart_tx waveform (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/tb_uart_tx_v.png) |
+| `uart_tx` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/uart_tx.svg" alt="uart_tx netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/uart_tx_v.svg" alt="uart_tx netlist (Verilog)" width="480"> |
+| `tb_uart_tx` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/tb_uart_tx.png" alt="uart_tx waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/uart_tx/tb_uart_tx_v.png" alt="uart_tx waveform (Verilog)" width="480"> |
 
 </details>
 
@@ -109,8 +109,8 @@ and Verilog on the right so you can compare the two directly.
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `shift_register` (netlist) | ![shift_register netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/shift_register.svg) | ![shift_register netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/shift_register_v.svg) |
-| `tb_shift_register` | ![shift_register waveform (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/tb_shift_register.png) | ![shift_register waveform (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/tb_shift_register_v.png) |
+| `shift_register` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/shift_register.svg" alt="shift_register netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/shift_register_v.svg" alt="shift_register netlist (Verilog)" width="480"> |
+| `tb_shift_register` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/tb_shift_register.png" alt="shift_register waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/shift_register/tb_shift_register_v.png" alt="shift_register waveform (Verilog)" width="480"> |
 
 </details>
 
@@ -119,9 +119,9 @@ and Verilog on the right so you can compare the two directly.
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `fifo_sync` (netlist) | ![fifo_sync netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/fifo_sync.svg) | ![fifo_sync netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/fifo_sync_v.svg) |
-| `tb_fifo_sync` | ![fifo_sync tb_fifo_sync (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync.png) | ![fifo_sync tb_fifo_sync (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync_v.png) |
-| `tb_fifo_sync_overlapping` | ![fifo_sync tb_fifo_sync_overlapping (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync_overlapping.png) | ![fifo_sync tb_fifo_sync_overlapping (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync_overlapping_v.png) |
+| `fifo_sync` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/fifo_sync.svg" alt="fifo_sync netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/fifo_sync_v.svg" alt="fifo_sync netlist (Verilog)" width="480"> |
+| `tb_fifo_sync` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync.png" alt="fifo_sync tb_fifo_sync (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync_v.png" alt="fifo_sync tb_fifo_sync (Verilog)" width="480"> |
+| `tb_fifo_sync_overlapping` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync_overlapping.png" alt="fifo_sync tb_fifo_sync_overlapping (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/fifo_sync/tb_fifo_sync_overlapping_v.png" alt="fifo_sync tb_fifo_sync_overlapping (Verilog)" width="480"> |
 
 Two testbenches each side: `tb_fifo_sync` covers full-fill/drain/ordering, `tb_fifo_sync_overlapping` covers the simultaneous read+write case (occupancy invariance + ordering under overlap).
 
@@ -132,8 +132,8 @@ Two testbenches each side: `tb_fifo_sync` covers full-fill/drain/ordering, `tb_f
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `test` (netlist) | ![7seg counter netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/test.svg) | ![7seg counter netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/test_v.svg) |
-| `tb_test` (10 ms) | ![7seg counter waveform (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/tb_test.png) | ![7seg counter waveform (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/tb_test_v.png) |
+| `test` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/test.svg" alt="7seg counter netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/test_v.svg" alt="7seg counter netlist (Verilog)" width="480"> |
+| `tb_test` (10 ms) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/tb_test.png" alt="7seg counter waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/7segments-counter/tb_test_v.png" alt="7seg counter waveform (Verilog)" width="480"> |
 
 A second testbench `tb_test_long` (150 ms) runs in CI asserting the internal counter ticks, but dumps FST without a waveform screenshot (at that zoom level the 20 ns clock period is sub-pixel anyway).
 
@@ -144,8 +144,8 @@ A second testbench `tb_test_long` (150 ms) runs in CI asserting the internal cou
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `Serial2Parallel` (netlist) | ![Serial2Parallel netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel.svg) | ![Serial2Parallel netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel_v.svg) |
-| `Serial2Parallel_tb` | ![Serial2Parallel waveform (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel_tb.png) | ![Serial2Parallel waveform (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel_tb_v.png) |
+| `Serial2Parallel` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel.svg" alt="Serial2Parallel netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel_v.svg" alt="Serial2Parallel netlist (Verilog)" width="480"> |
+| `Serial2Parallel_tb` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel_tb.png" alt="Serial2Parallel waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/general_components/Serial2Parallel_tb_v.png" alt="Serial2Parallel waveform (Verilog)" width="480"> |
 
 </details>
 
@@ -154,8 +154,8 @@ A second testbench `tb_test_long` (150 ms) runs in CI asserting the internal cou
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `tl_simulator_writer` (netlist) | ![simulator_writer netlist (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tl_simulator_writer.svg) | ![simulator_writer netlist (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tl_simulator_writer_v.svg) |
-| `tb_simulator_writer` | ![simulator_writer waveform (VHDL)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tb_simulator_writer.png) | ![simulator_writer waveform (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tb_simulator_writer_v.png) |
+| `tl_simulator_writer` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tl_simulator_writer.svg" alt="simulator_writer netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tl_simulator_writer_v.svg" alt="simulator_writer netlist (Verilog)" width="480"> |
+| `tb_simulator_writer` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tb_simulator_writer.png" alt="simulator_writer waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/simulator_writer/tb_simulator_writer_v.png" alt="simulator_writer waveform (Verilog)" width="480"> |
 
 </details>
 
@@ -164,10 +164,10 @@ A second testbench `tb_test_long` (150 ms) runs in CI asserting the internal cou
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `sprite` (netlist) | ![vga_sprites netlist](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/sprite.svg) | ![vga_sprites sprite (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/sprite_v.svg) |
-| `tb_trigonometric` | ![vga_sprites tb_trigonometric](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_trigonometric.png) | ![vga_sprites tb_trigonometric (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_trigonometric_v.png) |
-| `tb_multiply_by_sin_lut` | ![vga_sprites tb_multiply_by_sin_lut](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_multiply_by_sin_lut.png) | ![vga_sprites tb_multiply_by_sin_lut (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_multiply_by_sin_lut_v.png) |
-| `tb_sprite_gravity` | ![vga_sprites tb_sprite_gravity](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_sprite_gravity.png) | ![vga_sprites tb_sprite_gravity (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_sprite_gravity_v.png) |
+| `sprite` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/sprite.svg" alt="vga_sprites sprite netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/sprite_v.svg" alt="vga_sprites sprite netlist (Verilog)" width="480"> |
+| `tb_trigonometric` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_trigonometric.png" alt="vga_sprites tb_trigonometric (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_trigonometric_v.png" alt="vga_sprites tb_trigonometric (Verilog)" width="480"> |
+| `tb_multiply_by_sin_lut` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_multiply_by_sin_lut.png" alt="vga_sprites tb_multiply_by_sin_lut (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_multiply_by_sin_lut_v.png" alt="vga_sprites tb_multiply_by_sin_lut (Verilog)" width="480"> |
+| `tb_sprite_gravity` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_sprite_gravity.png" alt="vga_sprites tb_sprite_gravity (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_sprite_gravity_v.png" alt="vga_sprites tb_sprite_gravity (Verilog)" width="480"> |
 
 Three focused testbenches: `tb_trigonometric` (integration sweep + rotate properties), `tb_multiply_by_sin_lut` (LUT unit tests — odd symmetry, anti-symmetry across π, mirror across π/2, magnitude bound), `tb_sprite_gravity` (sprite entity with gravity on — fall/bounce cause-effect check). VHDL and Verilog twins simulate the same sin/cos LUT and rotate() math; the trig functions live in `trigonometric_functions.vh` and are `\`include`d into each module that needs them.
 

--- a/README.md
+++ b/README.md
@@ -164,12 +164,12 @@ A second testbench `tb_test_long` (150 ms) runs in CI asserting the internal cou
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
-| `sprite` (netlist) | ![vga_sprites netlist](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/sprite.svg) | — |
-| `tb_trigonometric` | ![vga_sprites tb_trigonometric](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_trigonometric.png) | — |
-| `tb_multiply_by_sin_lut` | ![vga_sprites tb_multiply_by_sin_lut](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_multiply_by_sin_lut.png) | — |
-| `tb_sprite_gravity` | ![vga_sprites tb_sprite_gravity](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_sprite_gravity.png) | — |
+| `sprite` (netlist) | ![vga_sprites netlist](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/sprite.svg) | ![vga_sprites sprite (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/sprite_v.svg) |
+| `tb_trigonometric` | ![vga_sprites tb_trigonometric](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_trigonometric.png) | ![vga_sprites tb_trigonometric (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_trigonometric_v.png) |
+| `tb_multiply_by_sin_lut` | ![vga_sprites tb_multiply_by_sin_lut](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_multiply_by_sin_lut.png) | ![vga_sprites tb_multiply_by_sin_lut (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_multiply_by_sin_lut_v.png) |
+| `tb_sprite_gravity` | ![vga_sprites tb_sprite_gravity](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_sprite_gravity.png) | ![vga_sprites tb_sprite_gravity (Verilog)](https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/vga_sprites/tb_sprite_gravity_v.png) |
 
-Three focused testbenches: `tb_trigonometric` (integration sweep + rotate properties), `tb_multiply_by_sin_lut` (LUT unit tests — odd symmetry, anti-symmetry across π, mirror across π/2, magnitude bound), `tb_sprite_gravity` (sprite entity with gravity on — fall/bounce cause-effect check). No Verilog mirror yet.
+Three focused testbenches: `tb_trigonometric` (integration sweep + rotate properties), `tb_multiply_by_sin_lut` (LUT unit tests — odd symmetry, anti-symmetry across π, mirror across π/2, magnitude bound), `tb_sprite_gravity` (sprite entity with gravity on — fall/bounce cause-effect check). VHDL and Verilog twins simulate the same sin/cos LUT and rotate() math; the trig functions live in `trigonometric_functions.vh` and are `\`include`d into each module that needs them.
 
 </details>
 
@@ -264,7 +264,7 @@ declares `TOP / TB_TOPS / SRC_FILES / TB_FILES` (and optionally the
 | [7segments/counter](7segments/counter/)                     | ✅ | VHDL + Verilog | Multiplexed 4-digit counter.                                   |
 | [general_components](general_components/)                   | ✅ | VHDL + Verilog | Serial2Parallel (both languages) + Debounce (VHDL only).       |
 | [simulator_writer](simulator_writer/)                       | ✅ | VHDL + Verilog | VCD writer used to sanity-check the sim flow.                  |
-| [vga_sprites](vga_sprites/)                                 | ✅ | VHDL           | Rotating VGA sprites (trig LUT) + optional gravity.            |
+| [vga_sprites](vga_sprites/)                                 | ✅ | VHDL + Verilog | Rotating VGA sprites (trig LUT) + optional gravity.            |
 | [7segments/text](7segments/text/)                           | ⏳ | VHDL           | Sources present, no Makefile yet.                              |
 | [7segments/clock](7segments/clock/)                         | ⏳ | VHDL           | Fails to compile under current toolchain (see Roadmap).        |
 | [7segments/random_generator](7segments/random_generator/)   | ⏳ | VHDL           | Sources present, no Makefile yet.                              |

--- a/uart_tx/test/tb_uart_tx.vhd
+++ b/uart_tx/test/tb_uart_tx.vhd
@@ -24,7 +24,11 @@ architecture testbench of tb_uart_tx is
   signal sTxBusy   : std_logic;
   signal sSimulationActive   : boolean := true;
 
-  signal received  : std_logic_vector(7 downto 0);
+  -- Initialise to all zeros: each bit-time sets one bit individually,
+  -- so without this default the unset bits stay `'U'` until they are
+  -- written and the waveform shows a noisy build-up. The Verilog mirror
+  -- declares `reg [7:0] received = 8'h00`, so this matches it.
+  signal received  : std_logic_vector(7 downto 0) := (others => '0');
 begin
 
   dut : entity work.uart_tx

--- a/vga_sprites/Makefile
+++ b/vga_sprites/Makefile
@@ -16,4 +16,16 @@ TB_FILES  := test/tb_trigonometric.vhd \
 
 VHDL_STANDARD := 08
 
+# Verilog mirror. sprite.v + its three TBs pair 1:1 with the VHDL
+# above; trigonometric_functions.vh is ``include``d inside each module
+# that needs it, so V_INCDIRS covers both the synth path and the
+# testbench build.
+V_TOP       := sprite
+V_TB_TOPS   := tb_trigonometric tb_multiply_by_sin_lut tb_sprite_gravity
+V_SRC_FILES := sprite.v
+V_TB_FILES  := test/tb_trigonometric.v \
+               test/tb_multiply_by_sin_lut.v \
+               test/tb_sprite_gravity.v
+V_INCDIRS   := .
+
 include ../mk/common.mk

--- a/vga_sprites/sprite.v
+++ b/vga_sprites/sprite.v
@@ -1,0 +1,201 @@
+// sprite.v — Verilog mirror of sprite.vhd.
+//
+// VHDL uses record-typed generics (Pos2D, Speed2D, RotationSpeed,
+// GravityAcceleration, Size2D). Verilog has no records, so each record
+// field is exposed as its own integer parameter with a ``_X`` / ``_Y`` /
+// ``_PERIOD`` suffix. Instantiators pass them individually.
+
+`timescale 1ns/1ps
+
+`include "trigonometric_functions.vh"
+
+module sprite #(
+    parameter integer SCREEN_WIDTH                   = 800,
+    parameter integer SCREEN_HEIGHT                  = 600,
+    parameter integer SPRITE_WIDTH                   = 7,
+    parameter integer SCALE                          = 3,
+    parameter integer SPRITE_CONTENT_LEN             = 49,
+    parameter [SPRITE_CONTENT_LEN-1:0] SPRITE_CONTENT =
+        49'b1001001_0101010_0011100_1111111_0011100_0101010_1001001,
+    parameter integer INITIAL_ROTATION               = 0,
+    parameter integer INITIAL_ROTATION_INDEX_INC     = 1,
+    parameter integer INITIAL_ROTATION_UPDATE_PERIOD = 0,
+    parameter integer INITIAL_POSITION_X             = 0,
+    parameter integer INITIAL_POSITION_Y             = 0,
+    parameter integer INITIAL_SPEED_X                = 0,
+    parameter integer INITIAL_SPEED_Y                = 0,
+    parameter integer INITIAL_SPEED_UPDATE_PERIOD    = 0,
+    parameter integer GRAVITY_ENABLED                = 0,
+    parameter integer GRAVITY_Y_INCREMENTS           = 1,
+    parameter integer GRAVITY_UPDATE_PERIOD          = 3000000
+) (
+    input  wire       inClock,
+    input  wire       inEnabled,
+    input  wire signed [31:0] inCursorX,
+    input  wire signed [31:0] inCursorY,
+    input  wire       inColision,
+    output wire       outShouldDraw
+);
+
+    // Sprite-size / half-scaled constants (VHDL SPRITE_SIZE record).
+    localparam integer SPRITE_HEIGHT          = SPRITE_CONTENT_LEN / SPRITE_WIDTH;
+    localparam integer C_HALF_SCALED_WIDTH    = SPRITE_WIDTH  * SCALE / 2;
+    localparam integer C_HALF_SCALED_HEIGHT   = SPRITE_HEIGHT * SCALE / 2;
+
+    // Unpack SPRITE_CONTENT into a 2D-indexable rom. Row `r`, column `c`
+    // of the VHDL sSpriteContent maps to SPRITE_CONTENT[r*SPRITE_WIDTH + c].
+    // Kept as a packed array of rows so the read in ProcessPosition is
+    // a plain index, not a full vector slice.
+    reg [SPRITE_WIDTH-1:0] sSpriteContent [0:SPRITE_HEIGHT-1];
+    integer initI, initJ;
+    initial begin
+        for (initI = 0; initI < SPRITE_HEIGHT; initI = initI + 1) begin
+            for (initJ = 0; initJ < SPRITE_WIDTH; initJ = initJ + 1) begin
+                sSpriteContent[initI][initJ] =
+                    SPRITE_CONTENT[initI * SPRITE_WIDTH + initJ];
+            end
+        end
+    end
+
+    reg signed [31:0] sSpritePosX = INITIAL_POSITION_X;
+    reg signed [31:0] sSpritePosY = INITIAL_POSITION_Y;
+    reg signed [31:0] sCenterPosX = 0;
+    reg signed [31:0] sCenterPosY = 0;
+
+    reg signed [31:0] sCurrentSpeedX             = INITIAL_SPEED_X;
+    reg signed [31:0] sCurrentSpeedY             = INITIAL_SPEED_Y;
+    reg signed [31:0] sCurrentRotationIndexInc   = INITIAL_ROTATION_INDEX_INC;
+
+    reg [4:0] sRotation = INITIAL_ROTATION[4:0];
+    reg       sShouldDraw = 1'b0;
+    assign outShouldDraw = sShouldDraw;
+
+    // --- rotateSprite process ---------------------------------------------
+    reg [31:0] counterForSpriteRotationUpdate = 0;
+    reg [4:0]  indexForSpriteRotation         = 0;
+    always @(posedge inClock) begin
+        if (counterForSpriteRotationUpdate == INITIAL_ROTATION_UPDATE_PERIOD) begin
+            counterForSpriteRotationUpdate <= 0;
+            if ($signed(sCurrentRotationIndexInc) > 0) begin
+                if (indexForSpriteRotation == 5'd31)
+                    indexForSpriteRotation <= 5'd0;
+                else
+                    indexForSpriteRotation <= indexForSpriteRotation + sCurrentRotationIndexInc[4:0];
+            end else if ($signed(sCurrentRotationIndexInc) < 0) begin
+                if (indexForSpriteRotation == 5'd0)
+                    indexForSpriteRotation <= 5'd31;
+                else
+                    indexForSpriteRotation <= indexForSpriteRotation + sCurrentRotationIndexInc[4:0];
+            end
+        end else begin
+            counterForSpriteRotationUpdate <= counterForSpriteRotationUpdate + 1;
+        end
+        sRotation <= indexForSpriteRotation;
+    end
+
+    // --- moveSprite process -----------------------------------------------
+    reg [31:0] counterForSpritePositionUpdate     = 0;
+    reg [31:0] counterForVelocityUpdateByGravity  = 0;
+    reg signed [31:0] nextPositionToTestX;
+    reg signed [31:0] nextPositionToTestY;
+    reg signed [31:0] workingSpeedX;
+    reg signed [31:0] workingSpeedY;
+    reg               collisionDetected;
+    always @(posedge inClock) begin
+        workingSpeedX = sCurrentSpeedX;
+        workingSpeedY = sCurrentSpeedY;
+
+        if (GRAVITY_ENABLED != 0) begin
+            if (counterForVelocityUpdateByGravity == GRAVITY_UPDATE_PERIOD) begin
+                counterForVelocityUpdateByGravity <= 0;
+                workingSpeedY = workingSpeedY + GRAVITY_Y_INCREMENTS;
+            end else begin
+                counterForVelocityUpdateByGravity <= counterForVelocityUpdateByGravity + 1;
+            end
+        end
+
+        if (counterForSpritePositionUpdate == INITIAL_SPEED_UPDATE_PERIOD) begin
+            counterForSpritePositionUpdate <= 0;
+            collisionDetected = 1'b0;
+            nextPositionToTestX = sSpritePosX + workingSpeedX;
+            nextPositionToTestY = sSpritePosY + workingSpeedY;
+            if ((nextPositionToTestX - C_HALF_SCALED_WIDTH  <= 0) ||
+                (nextPositionToTestX + C_HALF_SCALED_WIDTH  >= SCREEN_WIDTH)) begin
+                workingSpeedX    = -workingSpeedX;
+                collisionDetected = 1'b1;
+            end
+            if ((nextPositionToTestY - C_HALF_SCALED_HEIGHT <= 0) ||
+                (nextPositionToTestY + C_HALF_SCALED_HEIGHT >= SCREEN_HEIGHT)) begin
+                workingSpeedY    = -workingSpeedY;
+                if ((GRAVITY_ENABLED != 0) && (workingSpeedY > 1))
+                    workingSpeedY = 32'sd1;
+                collisionDetected = 1'b1;
+            end
+            sSpritePosX <= sSpritePosX + workingSpeedX;
+            sSpritePosY <= sSpritePosY + workingSpeedY;
+            if (collisionDetected || (inColision && sShouldDraw))
+                sCurrentRotationIndexInc <= -sCurrentRotationIndexInc;
+            if (inColision && sShouldDraw) begin
+                workingSpeedX = -workingSpeedX;
+                workingSpeedY = -workingSpeedY;
+            end
+        end else begin
+            counterForSpritePositionUpdate <= counterForSpritePositionUpdate + 1;
+        end
+
+        sCurrentSpeedX <= workingSpeedX;
+        sCurrentSpeedY <= workingSpeedY;
+    end
+
+    // --- ProcessPosition process ------------------------------------------
+    // Cursor miss / hit check + rotation-aware lookup into sSpriteContent.
+    reg signed [31:0] vCursorX;
+    reg signed [31:0] vCursorY;
+    reg signed [31:0] vTransX;
+    reg signed [31:0] vTransY;
+    always @(posedge inClock) begin
+        if (!inEnabled) begin
+            sShouldDraw <= 1'b0;
+        end else begin
+            sCenterPosX <= sSpritePosX;
+            sCenterPosY <= sSpritePosY;
+
+            vCursorX = inCursorX;
+            vCursorY = inCursorY;
+
+            if ((vCursorX < (sCenterPosX - C_HALF_SCALED_WIDTH))  ||
+                (vCursorX > (sCenterPosX + C_HALF_SCALED_WIDTH))  ||
+                (vCursorY < (sCenterPosY - C_HALF_SCALED_HEIGHT)) ||
+                (vCursorY > (sCenterPosY + C_HALF_SCALED_HEIGHT))) begin
+                sShouldDraw <= 1'b0;
+            end else begin
+                vTransX = (vCursorX - (sCenterPosX - C_HALF_SCALED_WIDTH))  / SCALE;
+                vTransY = (vCursorY - (sCenterPosY - C_HALF_SCALED_HEIGHT)) / SCALE;
+                vTransX = translateOriginToCenterOfSprite_x(SPRITE_WIDTH,  vTransX);
+                vTransY = translateOriginToCenterOfSprite_y(SPRITE_HEIGHT, vTransY);
+                // rotate() takes the two axes together; in Verilog we
+                // materialise one axis at a time through the two helper
+                // functions. Each uses the ORIGINAL vTransX/vTransY —
+                // same as the VHDL, which reads position.x/position.y
+                // of the pre-rotation variable.
+                begin : rotate_block
+                    reg signed [31:0] preX, preY;
+                    preX = vTransX;
+                    preY = vTransY;
+                    vTransX = rotate_x(SPRITE_WIDTH, SPRITE_HEIGHT, preX, preY, sRotation);
+                    vTransY = rotate_y(SPRITE_WIDTH, SPRITE_HEIGHT, preX, preY, sRotation);
+                end
+                vTransX = translateOriginBackToFirstBitCorner_x(SPRITE_WIDTH,  vTransX);
+                vTransY = translateOriginBackToFirstBitCorner_y(SPRITE_HEIGHT, vTransY);
+
+                if ((vTransX < 0) || (vTransX > SPRITE_WIDTH  - 1) ||
+                    (vTransY < 0) || (vTransY > SPRITE_HEIGHT - 1)) begin
+                    sShouldDraw <= 1'b0;
+                end else begin
+                    sShouldDraw <= sSpriteContent[vTransY[31:0]][vTransX[31:0]];
+                end
+            end
+        end
+    end
+
+endmodule

--- a/vga_sprites/test/tb_multiply_by_sin_lut.v
+++ b/vga_sprites/test/tb_multiply_by_sin_lut.v
@@ -1,0 +1,139 @@
+// tb_multiply_by_sin_lut.v — Verilog mirror of tb_multiply_by_sin_lut.vhd.
+//
+// Unit test for ``multiplyBySinLUT``. Asserts the same four algebraic
+// properties as the VHDL TB:
+//   (A) odd symmetry in input          L(idx, -x) ≈ -L(idx, +x)
+//   (B) anti-symmetry across π         L(idx + 16, x) ≈ -L(idx, x)
+//   (C) mirror across π/2              L(16 - idx, x) ≈  L(idx, x)
+//   (D) bounded output                 |L(idx, x)| ≤ |x| + 1
+//
+// Tolerance ±1 (TOL) on (A)–(C) mirrors the VHDL — two's-complement
+// truncation makes |-128| vs |+127| asymmetric, which shows up at the
+// nibble level as ±1.
+
+`timescale 1ns/1ps
+
+`include "trigonometric_functions.vh"
+
+module tb_multiply_by_sin_lut;
+
+    localparam integer TOL = 1;
+
+    reg  [7:0] sStage            = 8'd0;
+    reg  [4:0] sIdx              = 5'd0;
+    reg  [7:0] sInput            = 8'd0;
+    reg  signed [31:0] sOutput   = 32'd0;
+    reg        sClock            = 1'b0;
+    reg        sSimulationActive = 1'b1;
+
+    function automatic integer abs_i(input integer v);
+        abs_i = (v < 0) ? -v : v;
+    endfunction
+
+    // Call the LUT with (idx, signed integer input) and return a signed
+    // integer. `idx mod 32` and the 8-bit cast mirror the VHDL helper.
+    function automatic integer call_lut(input integer idx, input integer x);
+        reg [4:0] vIdx;
+        reg [7:0] vIn;
+        reg [7:0] vOut;
+        begin
+            vIdx = idx[4:0];
+            vIn  = x[7:0];
+            vOut = multiplyBySinLUT(vIdx, vIn);
+            call_lut = $signed(vOut);
+        end
+    endfunction
+
+    initial begin
+        $dumpfile(`VCD_OUT);
+        $dumpvars(1, tb_multiply_by_sin_lut);
+    end
+
+    initial begin : driver
+        integer idx, xMag, x;
+        integer vPos, vNeg, vRef, vDelta;
+        // (A) odd symmetry.
+        sStage <= 8'd1;
+        for (idx = 0; idx < 32; idx = idx + 1) begin
+            for (xMag = 1; xMag <= 127; xMag = xMag + 1) begin
+                if ((xMag % 16) == 1 || xMag == 127) begin
+                    sIdx   <= idx[4:0];
+                    sInput <= xMag[7:0];
+                    vPos   = call_lut(idx,  xMag);
+                    vNeg   = call_lut(idx, -xMag);
+                    vDelta = vPos + vNeg;
+                    sOutput <= vPos;
+                    if (abs_i(vDelta) > TOL)
+                        $fatal(1, "A: odd symmetry broken at idx=%0d |x|=%0d: L(+x)=%0d L(-x)=%0d",
+                                  idx, xMag, vPos, vNeg);
+                    sClock <= ~sClock;
+                    #20;
+                end
+            end
+        end
+
+        // (B) anti-symmetry across π.
+        sStage <= 8'd2;
+        for (idx = 0; idx < 16; idx = idx + 1) begin
+            for (x = -64; x <= 64; x = x + 1) begin
+                if ((x % 16) == 0) begin
+                    sIdx   <= idx[4:0];
+                    sInput <= x[7:0];
+                    vPos   = call_lut(idx,      x);
+                    vRef   = call_lut(idx + 16, x);
+                    vDelta = vPos + vRef;
+                    sOutput <= vPos;
+                    if (abs_i(vDelta) > TOL)
+                        $fatal(1, "B: anti-symmetry across pi broken at idx=%0d x=%0d: L(idx)=%0d L(idx+16)=%0d",
+                                  idx, x, vPos, vRef);
+                    sClock <= ~sClock;
+                    #20;
+                end
+            end
+        end
+
+        // (C) mirror across π/2.
+        sStage <= 8'd3;
+        for (idx = 1; idx < 16; idx = idx + 1) begin
+            for (x = -64; x <= 64; x = x + 1) begin
+                if ((x % 16) == 0) begin
+                    sIdx   <= idx[4:0];
+                    sInput <= x[7:0];
+                    vPos   = call_lut(idx,      x);
+                    vRef   = call_lut(16 - idx, x);
+                    vDelta = vPos - vRef;
+                    sOutput <= vPos;
+                    if (abs_i(vDelta) > TOL)
+                        $fatal(1, "C: mirror across pi/2 broken at idx=%0d x=%0d: L(idx)=%0d L(16-idx)=%0d",
+                                  idx, x, vPos, vRef);
+                    sClock <= ~sClock;
+                    #20;
+                end
+            end
+        end
+
+        // (D) |L(idx, x)| <= |x| + 1.
+        sStage <= 8'd4;
+        for (idx = 0; idx < 32; idx = idx + 1) begin
+            for (x = -127; x <= 127; x = x + 1) begin
+                if ((x % 32) == 0 || x == 127 || x == -127) begin
+                    sIdx   <= idx[4:0];
+                    sInput <= x[7:0];
+                    vPos   = call_lut(idx, x);
+                    sOutput <= vPos;
+                    if (abs_i(vPos) > abs_i(x) + 1)
+                        $fatal(1, "D: bound |L(idx,x)| > |x|+1 at idx=%0d x=%0d L=%0d",
+                                  idx, x, vPos);
+                    sClock <= ~sClock;
+                    #20;
+                end
+            end
+        end
+
+        sStage <= 8'd99;
+        $display("tb_multiply_by_sin_lut simulation done!");
+        sSimulationActive <= 1'b0;
+        $finish;
+    end
+
+endmodule

--- a/vga_sprites/test/tb_sprite_gravity.v
+++ b/vga_sprites/test/tb_sprite_gravity.v
@@ -1,0 +1,98 @@
+// tb_sprite_gravity.v — Verilog mirror of tb_sprite_gravity.vhd.
+//
+// Exercises the `sprite` module with GRAVITY_ENABLED=1 via the same
+// cause-and-effect pattern as the VHDL TB:
+//   Stage 1: cursor at the sprite's initial center -> outShouldDraw = 1.
+//   Stage 2: after 300 us of gravity accumulation, cursor back at the
+//            original center -> outShouldDraw = 0 (sprite has fallen
+//            out of that pixel).
+//
+// Record-typed VHDL generics are flattened into individual ``_X`` / ``_Y``
+// parameters (no records in Verilog).
+
+`timescale 1ns/1ps
+
+module tb_sprite_gravity;
+
+    localparam integer CLK_PERIOD  = 20;
+    localparam integer SCREEN_W    = 60;
+    localparam integer SCREEN_H    = 40;
+    localparam integer INIT_CENT_X = 30;
+    localparam integer INIT_CENT_Y = 8;
+
+    reg               tbClock            = 1'b0;
+    reg  signed [31:0] tbCursorX         = 32'd0;
+    reg  signed [31:0] tbCursorY         = 32'd0;
+    wire              tbShouldDraw;
+    reg               sSimulationActive  = 1'b1;
+    reg  [7:0]        tbStage            = 8'd0;
+
+    sprite #(
+        .SCREEN_WIDTH                  (SCREEN_W),
+        .SCREEN_HEIGHT                 (SCREEN_H),
+        .SPRITE_WIDTH                  (3),
+        .SCALE                         (1),
+        .SPRITE_CONTENT_LEN            (9),
+        .SPRITE_CONTENT                (9'b010_111_010),
+        .INITIAL_ROTATION              (0),
+        .INITIAL_ROTATION_INDEX_INC    (0),
+        .INITIAL_ROTATION_UPDATE_PERIOD(0),
+        .INITIAL_POSITION_X            (INIT_CENT_X),
+        .INITIAL_POSITION_Y            (INIT_CENT_Y),
+        .INITIAL_SPEED_X               (0),
+        .INITIAL_SPEED_Y               (0),
+        .INITIAL_SPEED_UPDATE_PERIOD   (20),
+        .GRAVITY_ENABLED               (1),
+        .GRAVITY_Y_INCREMENTS          (1),
+        .GRAVITY_UPDATE_PERIOD         (10)
+    ) dut (
+        .inClock       (tbClock),
+        .inEnabled     (1'b1),
+        .inCursorX     (tbCursorX),
+        .inCursorY     (tbCursorY),
+        .inColision    (1'b0),
+        .outShouldDraw (tbShouldDraw)
+    );
+
+    always #(CLK_PERIOD/2) if (sSimulationActive) tbClock = ~tbClock;
+
+    // VHDL's sprite process variables (counters, nextPositionToTest,
+    // currentSpeed, collisionDetected, indexForSpriteRotation, etc.) do
+    // not appear in GHDL's VCD. sprite.v keeps them as module-scope regs
+    // for yosys compatibility — list the signals we actually want dumped
+    // here so the waveform matches the VHDL twin.
+    initial begin
+        $dumpfile(`VCD_OUT);
+        $dumpvars(1, tb_sprite_gravity);
+        $dumpvars(0, dut.inClock, dut.inEnabled, dut.inColision,
+                     dut.outShouldDraw,
+                     dut.sSpritePosX, dut.sSpritePosY,
+                     dut.sRotation, dut.sShouldDraw);
+    end
+
+    initial begin : driver
+        // Stage 1 — cursor on initial center; outShouldDraw should rise.
+        tbStage   <= 8'd1;
+        tbCursorX <= INIT_CENT_X;
+        tbCursorY <= INIT_CENT_Y;
+        #(10 * CLK_PERIOD);
+        if (tbShouldDraw !== 1'b1)
+            $fatal(1, "gravity TB stage 1: cursor at sprite center should draw, but outShouldDraw is 0");
+
+        // Stage 2 — let gravity pull the sprite clear of the initial pixel.
+        tbStage <= 8'd2;
+        #(300_000);                     // 300 us
+
+        tbCursorX <= INIT_CENT_X;       // re-sample original center
+        tbCursorY <= INIT_CENT_Y;
+        #(4 * CLK_PERIOD);
+        if (tbShouldDraw !== 1'b0)
+            $fatal(1, "gravity TB stage 2: sprite has not moved off the original center after 300 us -- gravity path regressed?");
+
+        tbStage <= 8'd99;
+        #(2 * CLK_PERIOD);
+        sSimulationActive <= 1'b0;
+        $finish;
+    end
+
+endmodule

--- a/vga_sprites/test/tb_trigonometric.v
+++ b/vga_sprites/test/tb_trigonometric.v
@@ -1,0 +1,156 @@
+// tb_trigonometric.v — Verilog mirror of tb_trigonometric.vhd.
+//
+// Two concurrent drivers:
+//   check_properties  — algebraic property checks on multiplyBySinLUT
+//                       and rotate(); failures call $fatal.
+//   sweep_for_waveform — stimulus sweep into signals so the gallery
+//                        PNG shows rotate() output over a (x,y) grid.
+//
+// The sweep deliberately does not gate on the checker — the waveform
+// is produced even if assertions fail, so the gallery reflects what
+// the LUT is actually computing at the point of failure.
+
+`timescale 1ns/1ps
+
+`include "trigonometric_functions.vh"
+
+module tb_trigonometric;
+
+    // Signals driven by the sweep (visible in the GTKWave PNG).
+    reg  [4:0]         indexForTableStdTestRotate = 5'd0;
+    reg  signed [31:0] sInputPosX                  = 32'd0;
+    reg  signed [31:0] sInputPosY                  = 32'd0;
+    reg  signed [31:0] sOutputPosX                 = 32'd0;
+    reg  signed [31:0] sOutputPosY                 = 32'd0;
+    reg                sClock                      = 1'b0;
+
+    // Signals the checker drives so its progress is also visible.
+    reg  [7:0]         checkerStage      = 8'd0;
+    reg  [4:0]         checkerLUTIndex   = 5'd0;
+    reg  [7:0]         checkerLUTInput   = 8'd0;
+    reg  [7:0]         checkerLUTOutput  = 8'd0;
+
+    reg                sSimulationActive = 1'b1;
+
+    localparam integer SPRITE_SIZE_CHECK_W = 11;
+    localparam integer SPRITE_SIZE_CHECK_H = 11;
+
+    initial begin
+        $dumpfile(`VCD_OUT);
+        $dumpvars(1, tb_trigonometric);
+    end
+
+    function automatic integer abs_i(input integer v);
+        abs_i = (v < 0) ? -v : v;
+    endfunction
+
+    // --- check_properties -------------------------------------------------
+    initial begin : check_properties
+        integer ci, cpx, cpy;
+        reg  [4:0] cv_idx;
+        reg  [7:0] cv_input;
+        reg  [7:0] cv_output;
+        integer cv_rotX_pos, cv_rotY_pos;
+        integer cv_rotX_neg, cv_rotY_neg;
+        // Stage 1: sin(0)*x == 0 for every x.
+        checkerStage <= 8'd1;
+        for (ci = -128; ci <= 127; ci = ci + 1) begin
+            cv_idx    = 5'd0;
+            cv_input  = ci[7:0];
+            cv_output = multiplyBySinLUT(cv_idx, cv_input);
+            checkerLUTIndex  <= cv_idx;
+            checkerLUTInput  <= cv_input;
+            checkerLUTOutput <= cv_output;
+            if (cv_output !== 8'b00000000)
+                $fatal(1, "sin(0)*x should be 0, got %0d for input %0d", $signed(cv_output), ci);
+            #50;
+        end
+
+        // Stage 2: sin(pi)*x == 0.
+        checkerStage <= 8'd2;
+        for (ci = -128; ci <= 127; ci = ci + 1) begin
+            cv_idx    = 5'd16;
+            cv_input  = ci[7:0];
+            cv_output = multiplyBySinLUT(cv_idx, cv_input);
+            checkerLUTIndex  <= cv_idx;
+            checkerLUTInput  <= cv_input;
+            checkerLUTOutput <= cv_output;
+            if (cv_output !== 8'b00000000)
+                $fatal(1, "sin(pi)*x should be 0, got %0d for input %0d", $signed(cv_output), ci);
+            #50;
+        end
+
+        // Stage 3: sin(·)*0 == 0.
+        checkerStage <= 8'd3;
+        for (ci = 0; ci < 32; ci = ci + 1) begin
+            cv_idx    = ci[4:0];
+            cv_input  = 8'd0;
+            cv_output = multiplyBySinLUT(cv_idx, cv_input);
+            checkerLUTIndex  <= cv_idx;
+            checkerLUTInput  <= cv_input;
+            checkerLUTOutput <= cv_output;
+            if (cv_output !== 8'b00000000)
+                $fatal(1, "sin(idx)*0 should be 0, got %0d for idx %0d", $signed(cv_output), ci);
+            #50;
+        end
+
+        // Stage 4: rotate((0,0), idx) == (0,0).
+        checkerStage <= 8'd4;
+        for (ci = 0; ci < 32; ci = ci + 1) begin
+            cv_idx = ci[4:0];
+            cv_rotX_pos = rotate_x(SPRITE_SIZE_CHECK_W, SPRITE_SIZE_CHECK_H, 0, 0, cv_idx);
+            cv_rotY_pos = rotate_y(SPRITE_SIZE_CHECK_W, SPRITE_SIZE_CHECK_H, 0, 0, cv_idx);
+            if ((cv_rotX_pos !== 0) || (cv_rotY_pos !== 0))
+                $fatal(1, "rotate((0,0), idx=%0d) should be (0,0), got (%0d, %0d)",
+                          ci, cv_rotX_pos, cv_rotY_pos);
+            #50;
+        end
+
+        // Stage 5: rotate linearity (±2 tolerance per axis, per VHDL TB).
+        checkerStage <= 8'd5;
+        for (ci = 0; ci < 32; ci = ci + 1) begin
+            cv_idx = ci[4:0];
+            for (cpx = 1; cpx <= 5; cpx = cpx + 1) begin
+                for (cpy = 1; cpy <= 5; cpy = cpy + 1) begin
+                    cv_rotX_pos = rotate_x(SPRITE_SIZE_CHECK_W, SPRITE_SIZE_CHECK_H,  cpx*10,  cpy*10, cv_idx);
+                    cv_rotY_pos = rotate_y(SPRITE_SIZE_CHECK_W, SPRITE_SIZE_CHECK_H,  cpx*10,  cpy*10, cv_idx);
+                    cv_rotX_neg = rotate_x(SPRITE_SIZE_CHECK_W, SPRITE_SIZE_CHECK_H, -cpx*10, -cpy*10, cv_idx);
+                    cv_rotY_neg = rotate_y(SPRITE_SIZE_CHECK_W, SPRITE_SIZE_CHECK_H, -cpx*10, -cpy*10, cv_idx);
+                    if ((abs_i(cv_rotX_neg + cv_rotX_pos) > 2) ||
+                        (abs_i(cv_rotY_neg + cv_rotY_pos) > 2))
+                        $fatal(1, "rotate linearity broken at idx=%0d pos=(%0d,%0d): rot(+)=(%0d,%0d) rot(-)=(%0d,%0d)",
+                                  ci, cpx*10, cpy*10, cv_rotX_pos, cv_rotY_pos, cv_rotX_neg, cv_rotY_neg);
+                    #50;
+                end
+            end
+        end
+
+        checkerStage <= 8'd99;
+    end
+
+    // --- sweep_for_waveform -----------------------------------------------
+    initial begin : sweep_for_waveform
+        integer sr, sx, sy;
+        integer vOutX, vOutY;
+        for (sr = 0; sr < 32; sr = sr + 1) begin
+            indexForTableStdTestRotate <= sr[4:0];
+            for (sx = -5; sx <= 5; sx = sx + 1) begin
+                for (sy = -5; sy <= 5; sy = sy + 1) begin
+                    sClock <= 1'b0;
+                    #500;
+                    sInputPosX <= sx;
+                    sInputPosY <= sy;
+                    vOutX = rotate_x(11, 11, sx, sy, sr[4:0]);
+                    vOutY = rotate_y(11, 11, sx, sy, sr[4:0]);
+                    sOutputPosX <= vOutX;
+                    sOutputPosY <= vOutY;
+                    sClock <= 1'b1;
+                    #1000;
+                end
+            end
+        end
+        sSimulationActive <= 1'b0;
+        $finish;
+    end
+
+endmodule

--- a/vga_sprites/trigonometric_functions.vh
+++ b/vga_sprites/trigonometric_functions.vh
@@ -1,0 +1,265 @@
+// trigonometric_functions.vh — Verilog mirror of trigonometric.vhd.
+//
+// Meant to be ``include``d *inside* a module body. Provides:
+//
+//   multiplyBySinLUT(index, inputValue)  — 8-bit signed output
+//   multiplyByCosLUT(index, inputValue)
+//   rotate_x(sprite_w, sprite_h, px, py, rotation) — Pos2D.x component
+//   rotate_y(sprite_w, sprite_h, px, py, rotation) — Pos2D.y component
+//   translateOriginToCenterOfSprite_x / _y (sprite_w, sprite_h, x, y)
+//   translateOriginBackToFirstBitCorner_x / _y (sprite_w, sprite_h, x, y)
+//
+// All math mirrors the VHDL bit-for-bit (8-bit fixed-point truncation
+// toward zero), so the property assertions in the testbenches hit the
+// same numerical ranges GHDL produces.
+
+`ifndef TRIGONOMETRIC_FUNCTIONS_VH
+`define TRIGONOMETRIC_FUNCTIONS_VH
+
+// 16-row x 16-col sin·x LUT (8-bit unsigned). Indexed by the low 4 bits
+// of the rotation index and the 4-bit nibble of |inputValue|. The high
+// bit of the rotation index selects the output sign (the "sinIsNegative"
+// bit in the VHDL).
+function automatic [7:0] trig_lut_entry(input [3:0] row, input [3:0] col);
+    case ({row, col})
+        8'h00: trig_lut_entry = 8'b00000000; 8'h01: trig_lut_entry = 8'b00000000;
+        8'h02: trig_lut_entry = 8'b00000000; 8'h03: trig_lut_entry = 8'b00000000;
+        8'h04: trig_lut_entry = 8'b00000000; 8'h05: trig_lut_entry = 8'b00000000;
+        8'h06: trig_lut_entry = 8'b00000000; 8'h07: trig_lut_entry = 8'b00000000;
+        8'h08: trig_lut_entry = 8'b00000000; 8'h09: trig_lut_entry = 8'b00000000;
+        8'h0A: trig_lut_entry = 8'b00000000; 8'h0B: trig_lut_entry = 8'b00000000;
+        8'h0C: trig_lut_entry = 8'b00000000; 8'h0D: trig_lut_entry = 8'b00000000;
+        8'h0E: trig_lut_entry = 8'b00000000; 8'h0F: trig_lut_entry = 8'b00000000;
+
+        8'h10: trig_lut_entry = 8'b00000000; 8'h11: trig_lut_entry = 8'b00000011;
+        8'h12: trig_lut_entry = 8'b00000110; 8'h13: trig_lut_entry = 8'b00001001;
+        8'h14: trig_lut_entry = 8'b00001100; 8'h15: trig_lut_entry = 8'b00001111;
+        8'h16: trig_lut_entry = 8'b00010010; 8'h17: trig_lut_entry = 8'b00010101;
+        8'h18: trig_lut_entry = 8'b00011000; 8'h19: trig_lut_entry = 8'b00011011;
+        8'h1A: trig_lut_entry = 8'b00011110; 8'h1B: trig_lut_entry = 8'b00100001;
+        8'h1C: trig_lut_entry = 8'b00100100; 8'h1D: trig_lut_entry = 8'b00100111;
+        8'h1E: trig_lut_entry = 8'b00101010; 8'h1F: trig_lut_entry = 8'b00101101;
+
+        8'h20: trig_lut_entry = 8'b00000000; 8'h21: trig_lut_entry = 8'b00000110;
+        8'h22: trig_lut_entry = 8'b00001100; 8'h23: trig_lut_entry = 8'b00010010;
+        8'h24: trig_lut_entry = 8'b00011000; 8'h25: trig_lut_entry = 8'b00011110;
+        8'h26: trig_lut_entry = 8'b00100100; 8'h27: trig_lut_entry = 8'b00101010;
+        8'h28: trig_lut_entry = 8'b00110000; 8'h29: trig_lut_entry = 8'b00110110;
+        8'h2A: trig_lut_entry = 8'b00111100; 8'h2B: trig_lut_entry = 8'b01000010;
+        8'h2C: trig_lut_entry = 8'b01001000; 8'h2D: trig_lut_entry = 8'b01001110;
+        8'h2E: trig_lut_entry = 8'b01010100; 8'h2F: trig_lut_entry = 8'b01011010;
+
+        8'h30: trig_lut_entry = 8'b00000000; 8'h31: trig_lut_entry = 8'b00001001;
+        8'h32: trig_lut_entry = 8'b00010010; 8'h33: trig_lut_entry = 8'b00011011;
+        8'h34: trig_lut_entry = 8'b00100100; 8'h35: trig_lut_entry = 8'b00101101;
+        8'h36: trig_lut_entry = 8'b00110110; 8'h37: trig_lut_entry = 8'b00111111;
+        8'h38: trig_lut_entry = 8'b01001000; 8'h39: trig_lut_entry = 8'b01010001;
+        8'h3A: trig_lut_entry = 8'b01011010; 8'h3B: trig_lut_entry = 8'b01100011;
+        8'h3C: trig_lut_entry = 8'b01101100; 8'h3D: trig_lut_entry = 8'b01110101;
+        8'h3E: trig_lut_entry = 8'b01111110; 8'h3F: trig_lut_entry = 8'b10000111;
+
+        8'h40: trig_lut_entry = 8'b00000000; 8'h41: trig_lut_entry = 8'b00001011;
+        8'h42: trig_lut_entry = 8'b00010110; 8'h43: trig_lut_entry = 8'b00100001;
+        8'h44: trig_lut_entry = 8'b00101100; 8'h45: trig_lut_entry = 8'b00110111;
+        8'h46: trig_lut_entry = 8'b01000010; 8'h47: trig_lut_entry = 8'b01001101;
+        8'h48: trig_lut_entry = 8'b01011000; 8'h49: trig_lut_entry = 8'b01100011;
+        8'h4A: trig_lut_entry = 8'b01101110; 8'h4B: trig_lut_entry = 8'b01111001;
+        8'h4C: trig_lut_entry = 8'b10000100; 8'h4D: trig_lut_entry = 8'b10001111;
+        8'h4E: trig_lut_entry = 8'b10011010; 8'h4F: trig_lut_entry = 8'b10100101;
+
+        8'h50: trig_lut_entry = 8'b00000000; 8'h51: trig_lut_entry = 8'b00001101;
+        8'h52: trig_lut_entry = 8'b00011010; 8'h53: trig_lut_entry = 8'b00100111;
+        8'h54: trig_lut_entry = 8'b00110100; 8'h55: trig_lut_entry = 8'b01000001;
+        8'h56: trig_lut_entry = 8'b01001110; 8'h57: trig_lut_entry = 8'b01011011;
+        8'h58: trig_lut_entry = 8'b01101000; 8'h59: trig_lut_entry = 8'b01110101;
+        8'h5A: trig_lut_entry = 8'b10000010; 8'h5B: trig_lut_entry = 8'b10001111;
+        8'h5C: trig_lut_entry = 8'b10011100; 8'h5D: trig_lut_entry = 8'b10101001;
+        8'h5E: trig_lut_entry = 8'b10110110; 8'h5F: trig_lut_entry = 8'b11000011;
+
+        8'h60: trig_lut_entry = 8'b00000000; 8'h61: trig_lut_entry = 8'b00001111;
+        8'h62: trig_lut_entry = 8'b00011110; 8'h63: trig_lut_entry = 8'b00101101;
+        8'h64: trig_lut_entry = 8'b00111100; 8'h65: trig_lut_entry = 8'b01001011;
+        8'h66: trig_lut_entry = 8'b01011010; 8'h67: trig_lut_entry = 8'b01101001;
+        8'h68: trig_lut_entry = 8'b01111000; 8'h69: trig_lut_entry = 8'b10000111;
+        8'h6A: trig_lut_entry = 8'b10010110; 8'h6B: trig_lut_entry = 8'b10100101;
+        8'h6C: trig_lut_entry = 8'b10110100; 8'h6D: trig_lut_entry = 8'b11000011;
+        8'h6E: trig_lut_entry = 8'b11010010; 8'h6F: trig_lut_entry = 8'b11100001;
+
+        // Rows 7-9 are identical — sin·x is approximately constant near
+        // peak sine.
+        8'h70: trig_lut_entry = 8'b00000000; 8'h71: trig_lut_entry = 8'b00010000;
+        8'h72: trig_lut_entry = 8'b00100000; 8'h73: trig_lut_entry = 8'b00110000;
+        8'h74: trig_lut_entry = 8'b01000000; 8'h75: trig_lut_entry = 8'b01010000;
+        8'h76: trig_lut_entry = 8'b01100000; 8'h77: trig_lut_entry = 8'b01110000;
+        8'h78: trig_lut_entry = 8'b10000000; 8'h79: trig_lut_entry = 8'b10010000;
+        8'h7A: trig_lut_entry = 8'b10100000; 8'h7B: trig_lut_entry = 8'b10110000;
+        8'h7C: trig_lut_entry = 8'b11000000; 8'h7D: trig_lut_entry = 8'b11010000;
+        8'h7E: trig_lut_entry = 8'b11100000; 8'h7F: trig_lut_entry = 8'b11110000;
+
+        8'h80: trig_lut_entry = 8'b00000000; 8'h81: trig_lut_entry = 8'b00010000;
+        8'h82: trig_lut_entry = 8'b00100000; 8'h83: trig_lut_entry = 8'b00110000;
+        8'h84: trig_lut_entry = 8'b01000000; 8'h85: trig_lut_entry = 8'b01010000;
+        8'h86: trig_lut_entry = 8'b01100000; 8'h87: trig_lut_entry = 8'b01110000;
+        8'h88: trig_lut_entry = 8'b10000000; 8'h89: trig_lut_entry = 8'b10010000;
+        8'h8A: trig_lut_entry = 8'b10100000; 8'h8B: trig_lut_entry = 8'b10110000;
+        8'h8C: trig_lut_entry = 8'b11000000; 8'h8D: trig_lut_entry = 8'b11010000;
+        8'h8E: trig_lut_entry = 8'b11100000; 8'h8F: trig_lut_entry = 8'b11110000;
+
+        8'h90: trig_lut_entry = 8'b00000000; 8'h91: trig_lut_entry = 8'b00010000;
+        8'h92: trig_lut_entry = 8'b00100000; 8'h93: trig_lut_entry = 8'b00110000;
+        8'h94: trig_lut_entry = 8'b01000000; 8'h95: trig_lut_entry = 8'b01010000;
+        8'h96: trig_lut_entry = 8'b01100000; 8'h97: trig_lut_entry = 8'b01110000;
+        8'h98: trig_lut_entry = 8'b10000000; 8'h99: trig_lut_entry = 8'b10010000;
+        8'h9A: trig_lut_entry = 8'b10100000; 8'h9B: trig_lut_entry = 8'b10110000;
+        8'h9C: trig_lut_entry = 8'b11000000; 8'h9D: trig_lut_entry = 8'b11010000;
+        8'h9E: trig_lut_entry = 8'b11100000; 8'h9F: trig_lut_entry = 8'b11110000;
+
+        // Rows 10-15 mirror 1-6 (sin(π/2 + θ) = sin(π/2 - θ)).
+        8'hA0: trig_lut_entry = 8'b00000000; 8'hA1: trig_lut_entry = 8'b00001111;
+        8'hA2: trig_lut_entry = 8'b00011110; 8'hA3: trig_lut_entry = 8'b00101101;
+        8'hA4: trig_lut_entry = 8'b00111100; 8'hA5: trig_lut_entry = 8'b01001011;
+        8'hA6: trig_lut_entry = 8'b01011010; 8'hA7: trig_lut_entry = 8'b01101001;
+        8'hA8: trig_lut_entry = 8'b01111000; 8'hA9: trig_lut_entry = 8'b10000111;
+        8'hAA: trig_lut_entry = 8'b10010110; 8'hAB: trig_lut_entry = 8'b10100101;
+        8'hAC: trig_lut_entry = 8'b10110100; 8'hAD: trig_lut_entry = 8'b11000011;
+        8'hAE: trig_lut_entry = 8'b11010010; 8'hAF: trig_lut_entry = 8'b11100001;
+
+        8'hB0: trig_lut_entry = 8'b00000000; 8'hB1: trig_lut_entry = 8'b00001101;
+        8'hB2: trig_lut_entry = 8'b00011010; 8'hB3: trig_lut_entry = 8'b00100111;
+        8'hB4: trig_lut_entry = 8'b00110100; 8'hB5: trig_lut_entry = 8'b01000001;
+        8'hB6: trig_lut_entry = 8'b01001110; 8'hB7: trig_lut_entry = 8'b01011011;
+        8'hB8: trig_lut_entry = 8'b01101000; 8'hB9: trig_lut_entry = 8'b01110101;
+        8'hBA: trig_lut_entry = 8'b10000010; 8'hBB: trig_lut_entry = 8'b10001111;
+        8'hBC: trig_lut_entry = 8'b10011100; 8'hBD: trig_lut_entry = 8'b10101001;
+        8'hBE: trig_lut_entry = 8'b10110110; 8'hBF: trig_lut_entry = 8'b11000011;
+
+        8'hC0: trig_lut_entry = 8'b00000000; 8'hC1: trig_lut_entry = 8'b00001011;
+        8'hC2: trig_lut_entry = 8'b00010110; 8'hC3: trig_lut_entry = 8'b00100001;
+        8'hC4: trig_lut_entry = 8'b00101100; 8'hC5: trig_lut_entry = 8'b00110111;
+        8'hC6: trig_lut_entry = 8'b01000010; 8'hC7: trig_lut_entry = 8'b01001101;
+        8'hC8: trig_lut_entry = 8'b01011000; 8'hC9: trig_lut_entry = 8'b01100011;
+        8'hCA: trig_lut_entry = 8'b01101110; 8'hCB: trig_lut_entry = 8'b01111001;
+        8'hCC: trig_lut_entry = 8'b10000100; 8'hCD: trig_lut_entry = 8'b10001111;
+        8'hCE: trig_lut_entry = 8'b10011010; 8'hCF: trig_lut_entry = 8'b10100101;
+
+        8'hD0: trig_lut_entry = 8'b00000000; 8'hD1: trig_lut_entry = 8'b00001001;
+        8'hD2: trig_lut_entry = 8'b00010010; 8'hD3: trig_lut_entry = 8'b00011011;
+        8'hD4: trig_lut_entry = 8'b00100100; 8'hD5: trig_lut_entry = 8'b00101101;
+        8'hD6: trig_lut_entry = 8'b00110110; 8'hD7: trig_lut_entry = 8'b00111111;
+        8'hD8: trig_lut_entry = 8'b01001000; 8'hD9: trig_lut_entry = 8'b01010001;
+        8'hDA: trig_lut_entry = 8'b01011010; 8'hDB: trig_lut_entry = 8'b01100011;
+        8'hDC: trig_lut_entry = 8'b01101100; 8'hDD: trig_lut_entry = 8'b01110101;
+        8'hDE: trig_lut_entry = 8'b01111110; 8'hDF: trig_lut_entry = 8'b10000111;
+
+        8'hE0: trig_lut_entry = 8'b00000000; 8'hE1: trig_lut_entry = 8'b00000110;
+        8'hE2: trig_lut_entry = 8'b00001100; 8'hE3: trig_lut_entry = 8'b00010010;
+        8'hE4: trig_lut_entry = 8'b00011000; 8'hE5: trig_lut_entry = 8'b00011110;
+        8'hE6: trig_lut_entry = 8'b00100100; 8'hE7: trig_lut_entry = 8'b00101010;
+        8'hE8: trig_lut_entry = 8'b00110000; 8'hE9: trig_lut_entry = 8'b00110110;
+        8'hEA: trig_lut_entry = 8'b00111100; 8'hEB: trig_lut_entry = 8'b01000010;
+        8'hEC: trig_lut_entry = 8'b01001000; 8'hED: trig_lut_entry = 8'b01001110;
+        8'hEE: trig_lut_entry = 8'b01010100; 8'hEF: trig_lut_entry = 8'b01011010;
+
+        8'hF0: trig_lut_entry = 8'b00000000; 8'hF1: trig_lut_entry = 8'b00000011;
+        8'hF2: trig_lut_entry = 8'b00000110; 8'hF3: trig_lut_entry = 8'b00001001;
+        8'hF4: trig_lut_entry = 8'b00001100; 8'hF5: trig_lut_entry = 8'b00001111;
+        8'hF6: trig_lut_entry = 8'b00010010; 8'hF7: trig_lut_entry = 8'b00010101;
+        8'hF8: trig_lut_entry = 8'b00011000; 8'hF9: trig_lut_entry = 8'b00011011;
+        8'hFA: trig_lut_entry = 8'b00011110; 8'hFB: trig_lut_entry = 8'b00100001;
+        8'hFC: trig_lut_entry = 8'b00100100; 8'hFD: trig_lut_entry = 8'b00100111;
+        8'hFE: trig_lut_entry = 8'b00101010; 8'hFF: trig_lut_entry = 8'b00101101;
+        default: trig_lut_entry = 8'b00000000;
+    endcase
+endfunction
+
+// sin(rotation)·inputValue, 8-bit signed. Mirrors VHDL
+// multiplyBySinLUT bit-for-bit: take |inputValue|, look up the two
+// nibbles in the sin-row, add the lower-nibble product into the upper
+// nibble of the 12-bit accumulator, then apply the combined sign
+// (sinIsNegative XOR inputIsNegative) and return bits [11:4].
+function automatic [7:0] multiplyBySinLUT(input [4:0] idx, input [7:0] inputValue);
+    reg        sinIsNegative;
+    reg        inputIsNegative;
+    reg [7:0]  absInput;
+    reg [3:0]  row;
+    reg [3:0]  loNib;
+    reg [3:0]  hiNib;
+    reg [7:0]  opProduct;     // row[loNib]
+    reg [11:0] sum;            // {row[hiNib], 4'b0} + opProduct
+    reg [11:0] signedSum;
+    begin
+        sinIsNegative   = idx[4];
+        inputIsNegative = inputValue[7];
+        absInput        = inputIsNegative ? (~inputValue + 8'd1) : inputValue;
+        row   = idx[3:0];
+        loNib = absInput[3:0];
+        hiNib = absInput[7:4];
+        opProduct = trig_lut_entry(row, loNib);
+        sum = {trig_lut_entry(row, hiNib), 4'b0000} + {4'b0000, opProduct};
+        if (sinIsNegative ^ inputIsNegative)
+            signedSum = -sum;
+        else
+            signedSum = sum;
+        multiplyBySinLUT = signedSum[11:4];
+    end
+endfunction
+
+// cos(idx) = sin(idx + 8) under a 32-step circle.
+function automatic [7:0] multiplyByCosLUT(input [4:0] idx, input [7:0] inputValue);
+    begin
+        multiplyByCosLUT = multiplyBySinLUT((idx + 5'd8) & 5'd31, inputValue);
+    end
+endfunction
+
+// rotate(): returns the two components of the rotated Pos2D as separate
+// integers. sprite_w / sprite_h are unused in the math itself (the
+// VHDL keeps them for a commented-out divisor), but exposed for parity.
+function automatic integer rotate_x(input integer sprite_w,
+                                    input integer sprite_h,
+                                    input integer px,
+                                    input integer py,
+                                    input [4:0]   rotation);
+    reg signed [7:0] cosPx;
+    reg signed [7:0] sinPy;
+    begin
+        cosPx = $signed(multiplyByCosLUT(rotation, px[7:0]));
+        sinPy = $signed(multiplyBySinLUT(rotation, py[7:0]));
+        rotate_x = cosPx - sinPy;
+    end
+endfunction
+
+function automatic integer rotate_y(input integer sprite_w,
+                                    input integer sprite_h,
+                                    input integer px,
+                                    input integer py,
+                                    input [4:0]   rotation);
+    reg signed [7:0] sinPx;
+    reg signed [7:0] cosPy;
+    begin
+        sinPx = $signed(multiplyBySinLUT(rotation, px[7:0]));
+        cosPy = $signed(multiplyByCosLUT(rotation, py[7:0]));
+        rotate_y = sinPx + cosPy;
+    end
+endfunction
+
+function automatic integer translateOriginToCenterOfSprite_x(input integer sprite_w,
+                                                             input integer x);
+    translateOriginToCenterOfSprite_x = x - (sprite_w / 2);
+endfunction
+
+function automatic integer translateOriginToCenterOfSprite_y(input integer sprite_h,
+                                                             input integer y);
+    translateOriginToCenterOfSprite_y = y - (sprite_h / 2);
+endfunction
+
+function automatic integer translateOriginBackToFirstBitCorner_x(input integer sprite_w,
+                                                                 input integer x);
+    translateOriginBackToFirstBitCorner_x = x + (sprite_w / 2);
+endfunction
+
+function automatic integer translateOriginBackToFirstBitCorner_y(input integer sprite_h,
+                                                                 input integer y);
+    translateOriginBackToFirstBitCorner_y = y + (sprite_h / 2);
+endfunction
+
+`endif


### PR DESCRIPTION
## Summary

Adds the Verilog twin of `vga_sprites` — the last CI-wired project that was still VHDL-only — so the gallery now shows side-by-side waveforms for every CI project.

The earlier multi-testbench infrastructure, gallery layout fix, and signal-set parity sweep already merged via #17. This PR is just the vga_sprites port on top.

### What's new

- `trigonometric_functions.vh` — sin/cos LUT + rotate + translate helpers, bit-for-bit mirror of `trigonometric.vhd` (8-bit fixed-point with the same nibble-level rounding). `\`include`d at file scope by every module that needs the math.
- `sprite.v` — sprite engine. Record-typed VHDL generics (Pos2D, Speed2D, RotationSpeed, GravityAcceleration) are flattened into individual per-axis / per-period integer parameters (Verilog has no records). The three internal processes (`rotateSprite`, `moveSprite`, `ProcessPosition`) are mirrored cycle-for-cycle.
- `tb_trigonometric.v` / `tb_multiply_by_sin_lut.v` / `tb_sprite_gravity.v` — same algebraic property checks (odd symmetry, anti-symmetry across pi, mirror across pi/2, magnitude bound, rotate fixed-point + linearity) and the same gravity cause/effect check as the VHDL TBs.

### Wiring

`vga_sprites/Makefile` picks up `V_TOP` / `V_TB_TOPS` / `V_SRC_FILES` / `V_TB_FILES` / `V_INCDIRS` — CI auto-discovers, no workflow edits needed.

README updated: gallery cells now show VHDL+Verilog side-by-side, the project table flag changes from `VHDL` to `VHDL + Verilog`.

### Out of scope

The non-CI VHDL-only projects (`7segments/{clock,random_generator,text}`, `i2s_test_1`, `rom_lut`, `uda1380`, `vga/{driver,text_generator}`, plus vga_sprites' own non-CI `top_level_vga_test` + `vga_driver`) are still VHDL-only. Porting them in this PR would have shipped thousands of lines of unverified Verilog (those projects have no CI test coverage to catch port bugs); a follow-up per-bucket is the better path.

## Test plan

- [x] `make all` for vga_sprites passes in the hdltools container — VHDL + Verilog: simulate, diagram, screenshot
- [x] All three Verilog TBs simulate and emit a VCD; assertions pass
- [x] `make diagram_v` synthesises sprite.v through yosys 0.64
- [x] Signal-name diff between VHDL and Verilog VCDs is clean modulo the unavoidable Pos2D record (VHDL hierarchical) vs flat per-axis (Verilog) split
- [ ] CI run is green on this PR
- [ ] Gallery comment renders the side-by-side cells correctly