### PR TITLE
glossary: symbol legend project (gates, muxes, arith, registers) with truth tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,83 @@ and Verilog on the right so you can compare the two directly.
 ### Basics
 
 <details open>
+<summary><b><code>glossary</code></b> — symbol legend: every primitive on one diagram, with truth tables</summary>
+
+| | VHDL | Verilog |
+| --- | :---: | :---: |
+| `glossary` (netlist) | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/basics-glossary/glossary.svg" alt="glossary netlist (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/basics-glossary/glossary_v.svg" alt="glossary netlist (Verilog)" width="480"> |
+| `tb_glossary` | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/basics-glossary/tb_glossary.png" alt="glossary waveform (VHDL)" width="480"> | <img src="https://raw.githubusercontent.com/naelolaiz/learning_fpga/ci-gallery/latest/basics-glossary/tb_glossary_v.png" alt="glossary waveform (Verilog)" width="480"> |
+
+A flat module that drives one output per primitive (bitwise gates, vector reductions, 2:1 / 4:1 muxes, adder / sub, comparators, shifters, plain / enabled / sync-reset D flip-flops, counter) so every cell appears once in the synthesised netlist with no fan-out clutter. The project ships a small custom `netlistsvg` skin that adds a text label across each IEEE gate shape (`AND`, `OR`, `NOT`, `XOR`, `NAND`, `NOR`, `XNOR`) so you can map shape ↔ name at a glance and then spot the same symbols in any other diagram below.
+
+<details>
+<summary>Truth tables for every primitive (click to expand)</summary>
+
+**Bitwise gates** (1-bit `a`, `b`)
+
+| `a` | `b` | `o_and` | `o_or` | `o_nand` | `o_nor` | `o_xor` | `o_xnor` |
+| :-: | :-: | :-----: | :----: | :------: | :-----: | :-----: | :------: |
+|  0  |  0  |    0    |   0    |    1     |    1    |    0    |     1    |
+|  0  |  1  |    0    |   1    |    1     |    0    |    1    |     0    |
+|  1  |  0  |    0    |   1    |    1     |    0    |    1    |     0    |
+|  1  |  1  |    1    |   1    |    0     |    0    |    0    |     1    |
+
+| `a` | `o_not` |
+| :-: | :-----: |
+|  0  |    1    |
+|  1  |    0    |
+
+**Vector reductions** (4-bit `av`)
+
+`reduce_or = av[3] | av[2] | av[1] | av[0]` (1 iff *any* bit is 1) · `reduce_and = av[3] & av[2] & av[1] & av[0]` (1 iff *all* bits are 1) · `reduce_xor = av[3] ^ av[2] ^ av[1] ^ av[0]` (1 iff an *odd* number of bits is 1 — parity).
+
+| `av`   | `o_reduce_or` | `o_reduce_and` | `o_reduce_xor` |
+| :----: | :-----------: | :------------: | :------------: |
+| `0000` |       0       |       0        |       0        |
+| `0001` |       1       |       0        |       1        |
+| `1010` |       1       |       0        |       0        |
+| `1100` |       1       |       0        |       0        |
+| `1101` |       1       |       0        |       1        |
+| `1111` |       1       |       1        |       0        |
+
+**Multiplexers**
+
+| `sel` | `o_mux2` |     | `sel4` | `o_mux4` |
+| :---: | :------: | --- | :----: | :------: |
+|   0   |   `b`    |     |  `00`  | `av[0]`  |
+|   1   |   `a`    |     |  `01`  | `av[1]`  |
+|       |          |     |  `10`  | `av[2]`  |
+|       |          |     |  `11`  | `av[3]`  |
+
+**Arithmetic, comparators, shifts** (4-bit operands, mod-16 wrap; example column uses `av = 1100` (12), `bv = 0011` (3))
+
+| Output  | Definition                          | Example                                  |
+| :-----: | ----------------------------------- | ---------------------------------------- |
+| `o_add` | `(av + bv) mod 16`                  | `1100 + 0011 = 1111` (12+3 = 15)         |
+| `o_sub` | `(av - bv) mod 16`                  | `1100 - 0011 = 1001` (12-3 = 9)          |
+| `o_eq`  | `1` iff `av == bv`                  | `0` (12 ≠ 3)                             |
+| `o_lt`  | `1` iff `av < bv` (unsigned)        | `0` (12 ≥ 3)                             |
+| `o_shl` | `av << 1`, MSB shifted out, LSB ← 0 | `1100 << 1 = 1000`                       |
+| `o_shr` | `av >> 1`, LSB shifted out, MSB ← 0 | `1100 >> 1 = 0110`                       |
+
+**Sequential cells** (`Q_next` is the value the register takes at the next rising edge of `clk`; outside a rising edge it simply *holds*)
+
+| Cell      | `clk` | `en` | `rst` | `a` | `Q_next`   |
+| :-------- | :---: | :--: | :---: | :-: | :--------: |
+| `dff`     |   ↑   |  —   |   —   |  0  |     0      |
+| `dff`     |   ↑   |  —   |   —   |  1  |     1      |
+| `dff_en`  |   ↑   |  0   |   —   |  x  |  *hold*    |
+| `dff_en`  |   ↑   |  1   |   —   |  a  |     a      |
+| `dff_rst` |   ↑   |  —   |   1   |  x  |     0      |
+| `dff_rst` |   ↑   |  —   |   0   |  a  |     a      |
+| `counter4`|   ↑   |  —   |   1   |  —  |  `0000`    |
+| `counter4`|   ↑   |  —   |   0   |  —  | `Q + 1` (mod 16) |
+
+</details>
+
+</details>
+
+<details>
 <summary><b><code>blink_led</code></b> — the "hello world": toggle an LED at 1 Hz</summary>
 
 | | VHDL | Verilog |
@@ -322,6 +399,7 @@ Projects are grouped by intent. Legend: ✅ built in CI · ⏳ pending adoption 
 
 | Project | CI | Languages | Notes |
 | --- | :-: | --- | --- |
+| [glossary](basics/glossary/)   | ✅ | VHDL + Verilog | Symbol legend: every primitive on one diagram (gates, muxes, arith, registers) with truth tables and a custom labelled-gate `netlistsvg` skin. |
 | [blink_led](basics/blink_led/) | ✅ | VHDL + Verilog | Hello-world LED toggler. |
 | [pwm_led](basics/pwm_led/)     | ✅ | VHDL + Verilog | Brightness via duty-cycle modulation. |
 

--- a/basics/glossary/Makefile
+++ b/basics/glossary/Makefile
@@ -1,0 +1,24 @@
+PROJECT_NAME := glossary
+
+TOP     := glossary
+TB_TOPS := tb_glossary
+
+SRC_FILES := glossary.vhd
+TB_FILES  := test/tb_glossary.vhd
+
+VHDL_STANDARD := 08
+
+# Verilog mirror — built side-by-side with the VHDL flow.
+V_TOP       := glossary
+V_TB_TOPS   := tb_glossary
+V_SRC_FILES := glossary.v
+V_TB_FILES  := test/tb_glossary.v
+
+# Render the netlist with our local skin: a copy of netlistsvg's default
+# with text labels (AND, OR, NOT, XOR, NAND, NOR, XNOR) added inside
+# each gate's IEEE distinctive shape so a reader can map shape ↔ name
+# at a glance. The skin lives in this directory so make -C glossary
+# resolves the relative path.
+NETLISTSVG := netlistsvg --skin skin.svg
+
+include ../../mk/common.mk

--- a/basics/glossary/README.md
+++ b/basics/glossary/README.md
@@ -1,0 +1,146 @@
+# glossary
+
+A flat module that instantiates one of every basic primitive in the
+synthesised netlist, with port names that describe the cell. Read it
+side-by-side with the rendered diagram (`build/glossary.svg` for the
+VHDL flow, `build/glossary_v.svg` for Verilog) to map each
+[netlistsvg](https://github.com/nturley/netlistsvg) shape to the
+construct that produced it.
+
+## Why
+
+`netlistsvg` renders the cells `yosys prep` leaves behind — a mix of
+IEEE distinctive shapes for bitwise gates and labelled boxes for
+reductions, muxes, adders, comparators and registers. The shapes are
+consistent across this repo's projects, so once you've identified a
+symbol here you can spot it in `pwm_led`, `fifo_sync`, `vga_sprites` or
+any other diagram in the [Gallery](../../README.md#gallery).
+
+This project ships a small `skin.svg` (a copy of netlistsvg's default
+with text labels added inside each gate template) so the AND / OR /
+NOT / XOR / NAND / NOR / XNOR shapes carry their name written across
+them. `Makefile` points netlistsvg at it via
+`NETLISTSVG := netlistsvg --skin skin.svg`. Other projects in the repo
+keep using the bare default skin and are unaffected.
+
+## What's in it
+
+The top-level `glossary` entity is purely for diagram-rendering: every
+output drives one isolated primitive, so each gets its own cell in the
+netlist with no fan-in/fan-out clutter from neighbouring logic.
+
+| Group           | Outputs                                              | What you'll see in the diagram                          |
+| --------------- | ---------------------------------------------------- | ------------------------------------------------------- |
+| Bitwise gates   | `o_and`, `o_or`, `o_not`, `o_xor`, `o_nand`, `o_nor`, `o_xnor` | IEEE distinctive shapes (D-shape AND, shield OR, inverter triangle, XOR with curve, bubble = invert). |
+| Reductions      | `o_reduce_or`, `o_reduce_and`, `o_reduce_xor`        | Same gate shape, but the input is a 4-bit bus — that's how netlistsvg flags a vector reduction. |
+| Multiplexers    | `o_mux2`, `o_mux4`                                   | Trapezoid box with the data inputs on the wide side and `S` (select) on the narrow side. |
+| Arithmetic      | `o_add`, `o_sub`                                     | Rectangular box labelled `+` / `-` with two bus inputs. |
+| Comparators     | `o_eq`, `o_lt`                                       | Box labelled `==` / `<`, two bus inputs, 1-bit output.  |
+| Shifters        | `o_shl`, `o_shr`                                     | Box labelled `<<` / `>>`.                               |
+| Sequential      | `o_dff`, `o_dffe`, `o_dffr`, `o_counter`             | Register box with a clock-edge notch (`▷`); `EN`/`SR` pins appear when the cell has them; the counter shows up as a register fed by an adder. |
+
+## Truth tables
+
+### Bitwise gates (1-bit `a`, `b`)
+
+| `a` | `b` | `o_and` | `o_or` | `o_nand` | `o_nor` | `o_xor` | `o_xnor` |
+| :-: | :-: | :-----: | :----: | :------: | :-----: | :-----: | :------: |
+|  0  |  0  |    0    |   0    |    1     |    1    |    0    |     1    |
+|  0  |  1  |    0    |   1    |    1     |    0    |    1    |     0    |
+|  1  |  0  |    0    |   1    |    1     |    0    |    1    |     0    |
+|  1  |  1  |    1    |   1    |    0     |    0    |    0    |     1    |
+
+| `a` | `o_not` |
+| :-: | :-----: |
+|  0  |    1    |
+|  1  |    0    |
+
+### Vector reductions (4-bit `av`)
+
+`reduce_or = av[3] | av[2] | av[1] | av[0]` — 1 iff *any* bit is 1.
+`reduce_and = av[3] & av[2] & av[1] & av[0]` — 1 iff *all* bits are 1.
+`reduce_xor = av[3] ^ av[2] ^ av[1] ^ av[0]` — 1 iff an *odd* number of bits is 1 (parity).
+
+| `av`   | `o_reduce_or` | `o_reduce_and` | `o_reduce_xor` |
+| :----: | :-----------: | :------------: | :------------: |
+| `0000` |       0       |       0        |       0        |
+| `0001` |       1       |       0        |       1        |
+| `1010` |       1       |       0        |       0        |
+| `1100` |       1       |       0        |       0        |
+| `1101` |       1       |       0        |       1        |
+| `1111` |       1       |       1        |       0        |
+
+### 2:1 multiplexer
+
+| `sel` | `o_mux2` |
+| :---: | :------: |
+|   0   |   `b`    |
+|   1   |   `a`    |
+
+### 4:1 multiplexer (binary-encoded selector)
+
+| `sel4` | `o_mux4` |
+| :----: | :------: |
+|  `00`  | `av[0]`  |
+|  `01`  | `av[1]`  |
+|  `10`  | `av[2]`  |
+|  `11`  | `av[3]`  |
+
+### Arithmetic, comparators, shifts (4-bit operands, mod-16 wrap)
+
+The example column uses the testbench stimulus `av = 1100` (12), `bv = 0011` (3).
+
+| Output  | Definition                          | Example                                  |
+| :-----: | ----------------------------------- | ---------------------------------------- |
+| `o_add` | `(av + bv) mod 16`                  | `1100 + 0011 = 1111` (12+3 = 15)         |
+| `o_sub` | `(av - bv) mod 16`                  | `1100 - 0011 = 1001` (12-3 = 9)          |
+| `o_eq`  | `1` iff `av == bv`                  | `0` (12 ≠ 3)                             |
+| `o_lt`  | `1` iff `av < bv` (unsigned)        | `0` (12 ≥ 3)                             |
+| `o_shl` | `av << 1`, MSB shifted out, LSB ← 0 | `1100 << 1 = 1000`                       |
+| `o_shr` | `av >> 1`, LSB shifted out, MSB ← 0 | `1100 >> 1 = 0110`                       |
+
+### Sequential cells
+
+`Q_next` = the value the register takes at the next rising edge of `clk`. Outside a rising edge, the register simply *holds*.
+
+**Plain D flip-flop** (`o_dff`)
+
+| `clk` | `a` | `Q_next` |
+| :---: | :-: | :------: |
+|   ↑   |  0  |    0     |
+|   ↑   |  1  |    1     |
+
+**D flip-flop with clock enable** (`o_dffe`)
+
+| `clk` | `en` | `a` | `Q_next` |
+| :---: | :--: | :-: | :------: |
+|   ↑   |  0   |  x  |  *hold*  |
+|   ↑   |  1   |  0  |    0     |
+|   ↑   |  1   |  1  |    1     |
+
+**D flip-flop with synchronous reset** (`o_dffr`)
+
+| `clk` | `rst` | `a` | `Q_next` |
+| :---: | :---: | :-: | :------: |
+|   ↑   |   1   |  x  |    0     |
+|   ↑   |   0   |  0  |    0     |
+|   ↑   |   0   |  1  |    1     |
+
+**4-bit counter** (`o_counter`)
+
+| `clk` | `rst` |  `Q_next`   |
+| :---: | :---: | :---------: |
+|   ↑   |   1   |   `0000`    |
+|   ↑   |   0   | `Q + 1` (mod 16) |
+
+## Testbench
+
+`tb_glossary` (both VHDL and Verilog mirrors) drives one representative
+pattern through the combinational outputs and three rising clock edges
+through the sequential ones, asserting the row of each truth/behaviour
+table that gets exercised. A failure means a primitive's behaviour
+diverged from its definition above.
+
+The testbenches use `av = 1100`, `bv = 0011`, `sel = 1`, `sel4 = 10`
+during the combinational phase, then sweep `(en, rst, a)` to cover the
+non-trivial rows of each sequential cell.

--- a/basics/glossary/glossary.v
+++ b/basics/glossary/glossary.v
@@ -1,0 +1,96 @@
+// Verilog mirror of glossary.vhd — same port shape, same behaviour.
+// Read alongside build/glossary_v.svg to map each netlistsvg shape to
+// its cell.
+
+`default_nettype none
+
+module glossary (
+    input  wire        a,
+    input  wire        b,
+    input  wire        sel,
+    input  wire [1:0]  sel4,
+    input  wire [3:0]  av,
+    input  wire [3:0]  bv,
+    input  wire        clk,
+    input  wire        rst,
+    input  wire        en,
+
+    output wire        o_and,
+    output wire        o_or,
+    output wire        o_not,
+    output wire        o_xor,
+    output wire        o_nand,
+    output wire        o_nor,
+    output wire        o_xnor,
+
+    output wire        o_reduce_or,
+    output wire        o_reduce_and,
+    output wire        o_reduce_xor,
+
+    output wire        o_mux2,
+    output wire        o_mux4,
+
+    output wire [3:0]  o_add,
+    output wire [3:0]  o_sub,
+    output wire        o_eq,
+    output wire        o_lt,
+    output wire [3:0]  o_shl,
+    output wire [3:0]  o_shr,
+
+    output wire        o_dff,
+    output wire        o_dffe,
+    output wire        o_dffr,
+    output wire [3:0]  o_counter
+);
+
+    assign o_and  =  (a & b);
+    assign o_or   =  (a | b);
+    assign o_not  =  ~a;
+    assign o_xor  =  (a ^ b);
+    assign o_nand = ~(a & b);
+    assign o_nor  = ~(a | b);
+    assign o_xnor = ~(a ^ b);
+
+    assign o_reduce_or  = | av;
+    assign o_reduce_and = & av;
+    assign o_reduce_xor = ^ av;
+
+    assign o_mux2 = sel ? a : b;
+    assign o_mux4 = (sel4 == 2'b00) ? av[0] :
+                    (sel4 == 2'b01) ? av[1] :
+                    (sel4 == 2'b10) ? av[2] :
+                                      av[3];
+
+    assign o_add = av + bv;
+    assign o_sub = av - bv;
+    assign o_eq  = (av == bv);
+    assign o_lt  = (av <  bv);
+    assign o_shl = av << 1;
+    assign o_shr = av >> 1;
+
+    reg       r_dff     = 1'b0;
+    reg       r_dffe    = 1'b0;
+    reg       r_dffr    = 1'b0;
+    reg [3:0] r_counter = 4'd0;
+
+    always @(posedge clk) r_dff <= a;
+
+    always @(posedge clk)
+        if (en) r_dffe <= a;
+
+    always @(posedge clk)
+        if (rst) r_dffr <= 1'b0;
+        else     r_dffr <= a;
+
+    always @(posedge clk)
+        if (rst) r_counter <= 4'd0;
+        else     r_counter <= r_counter + 4'd1;
+
+    assign o_dff     = r_dff;
+    assign o_dffe    = r_dffe;
+    assign o_dffr    = r_dffr;
+    assign o_counter = r_counter;
+
+endmodule
+
+`default_nettype wire

--- a/basics/glossary/glossary.vhd
+++ b/basics/glossary/glossary.vhd
@@ -1,0 +1,139 @@
+-- Glossary of basic logic primitives.
+--
+-- One module, one output per primitive — read alongside the rendered
+-- netlist diagram (build/glossary.svg) to learn which netlistsvg shape
+-- maps to which cell. The Verilog mirror in glossary.v is byte-for-byte
+-- equivalent in behaviour and port shape.
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity glossary is
+    port (
+        -- 1-bit combinational inputs
+        a    : in std_logic;
+        b    : in std_logic;
+        sel  : in std_logic;
+        sel4 : in std_logic_vector(1 downto 0);
+
+        -- 4-bit buses for reductions, arithmetic, shifts and the 4:1 mux
+        av : in std_logic_vector(3 downto 0);
+        bv : in std_logic_vector(3 downto 0);
+
+        -- sequential controls
+        clk : in std_logic;
+        rst : in std_logic;
+        en  : in std_logic;
+
+        -- bitwise gates
+        o_and  : out std_logic;
+        o_or   : out std_logic;
+        o_not  : out std_logic;
+        o_xor  : out std_logic;
+        o_nand : out std_logic;
+        o_nor  : out std_logic;
+        o_xnor : out std_logic;
+
+        -- vector reductions (VHDL-2008 unary operators)
+        o_reduce_or  : out std_logic;
+        o_reduce_and : out std_logic;
+        o_reduce_xor : out std_logic;
+
+        -- multiplexers
+        o_mux2 : out std_logic;
+        o_mux4 : out std_logic;
+
+        -- arithmetic + comparators + shifts
+        o_add : out std_logic_vector(3 downto 0);
+        o_sub : out std_logic_vector(3 downto 0);
+        o_eq  : out std_logic;
+        o_lt  : out std_logic;
+        o_shl : out std_logic_vector(3 downto 0);
+        o_shr : out std_logic_vector(3 downto 0);
+
+        -- sequential cells
+        o_dff     : out std_logic;
+        o_dffe    : out std_logic;
+        o_dffr    : out std_logic;
+        o_counter : out std_logic_vector(3 downto 0)
+    );
+end entity glossary;
+
+architecture rtl of glossary is
+    signal r_dff     : std_logic                    := '0';
+    signal r_dffe    : std_logic                    := '0';
+    signal r_dffr    : std_logic                    := '0';
+    signal r_counter : unsigned(3 downto 0)         := (others => '0');
+begin
+
+    o_and  <= a and  b;
+    o_or   <= a or   b;
+    o_not  <= not a;
+    o_xor  <= a xor  b;
+    o_nand <= a nand b;
+    o_nor  <= a nor  b;
+    o_xnor <= a xnor b;
+
+    o_reduce_or  <= or  av;
+    o_reduce_and <= and av;
+    o_reduce_xor <= xor av;
+
+    o_mux2 <= a when sel = '1' else b;
+
+    with sel4 select
+        o_mux4 <= av(0) when "00",
+                  av(1) when "01",
+                  av(2) when "10",
+                  av(3) when others;
+
+    o_add <= std_logic_vector(unsigned(av) + unsigned(bv));
+    o_sub <= std_logic_vector(unsigned(av) - unsigned(bv));
+    o_eq  <= '1' when av = bv else '0';
+    o_lt  <= '1' when unsigned(av) < unsigned(bv) else '0';
+    o_shl <= std_logic_vector(shift_left (unsigned(av), 1));
+    o_shr <= std_logic_vector(shift_right(unsigned(av), 1));
+
+    DFF : process (clk) is
+    begin
+        if rising_edge(clk) then
+            r_dff <= a;
+        end if;
+    end process DFF;
+    o_dff <= r_dff;
+
+    DFFE : process (clk) is
+    begin
+        if rising_edge(clk) then
+            if en = '1' then
+                r_dffe <= a;
+            end if;
+        end if;
+    end process DFFE;
+    o_dffe <= r_dffe;
+
+    DFFR : process (clk) is
+    begin
+        if rising_edge(clk) then
+            if rst = '1' then
+                r_dffr <= '0';
+            else
+                r_dffr <= a;
+            end if;
+        end if;
+    end process DFFR;
+    o_dffr <= r_dffr;
+
+    COUNTER : process (clk) is
+    begin
+        if rising_edge(clk) then
+            if rst = '1' then
+                r_counter <= (others => '0');
+            else
+                r_counter <= r_counter + 1;
+            end if;
+        end if;
+    end process COUNTER;
+    o_counter <= std_logic_vector(r_counter);
+
+end architecture rtl;

--- a/basics/glossary/skin.svg
+++ b/basics/glossary/skin.svg
@@ -1,0 +1,330 @@
+<svg  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:s="https://github.com/nturley/netlistsvg"
+  width="800" height="300">
+  <s:properties>
+    <s:layoutEngine
+      org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers="35"
+      org.eclipse.elk.spacing.nodeNode= "35"
+      org.eclipse.elk.layered.layering.strategy= "LONGEST_PATH"
+    />
+    <s:low_priority_alias val="$dff" />
+  </s:properties>
+<style>
+svg {
+  stroke:#000;
+  fill:none;
+}
+text {
+  fill:#000;
+  stroke:none;
+  font-size:10px;
+  font-weight: bold;
+  font-family: "Courier New", monospace;
+}
+.nodelabel {
+  text-anchor: middle;
+}
+.inputPortLabel {
+  text-anchor: end;
+}
+.splitjoinBody {
+  fill:#000;
+}
+</style>
+  <g s:type="mux" transform="translate(50, 50)" s:width="20" s:height="40">
+    <s:alias val="$pmux"/>
+    <s:alias val="$mux"/>
+    <s:alias val="$_MUX_"/>
+
+    <path d="M0,0 L20,10 L20,30 L0,40 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="0" s:y="30" s:pid="B"/>
+    <g s:x="10" s:y="35" s:pid="S"/>
+    <g s:x="20" s:y="20" s:pid="Y"/>
+  </g>
+
+  <!-- and -->
+  <g s:type="and" transform="translate(150,50)" s:width="30" s:height="25">
+    <s:alias val="$and"/>
+    <s:alias val="$reduce_and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="$cell_id"/>
+    <text x="13" y="15" class="nodelabel" style="font-size:7px">AND</text>
+
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="nand" transform="translate(150,100)" s:width="30" s:height="25">
+    <s:alias val="$nand"/>
+    <s:alias val="$logic_nand"/>
+    <s:alias val="$_NAND_"/>
+    <s:alias val="$_ANDNOT_"/>
+
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="$cell_id"/>
+    <circle cx="34" cy="12.5" r="3" class="$cell_id"/>
+    <text x="13" y="15" class="nodelabel" style="font-size:7px">NAND</text>
+
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="36" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <!-- or -->
+  <g s:type="or" transform="translate(250,50)" s:width="30" s:height="25">
+    <s:alias val="$or"/>
+    <s:alias val="$reduce_or"/>
+    <s:alias val="$reduce_bool"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+    <text x="17" y="15" class="nodelabel" style="font-size:7px">OR</text>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="reduce_nor" transform="translate(250, 100)" s:width="33" s:height="25">
+    <s:alias val="$nor"/>
+    <s:alias val="$reduce_nor"/>
+    <s:alias val="$_NOR_"/>
+    <s:alias val="$_ORNOT_"/>
+
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+    <circle cx="34" cy="12.5" r="3" class="$cell_id"/>
+    <text x="17" y="15" class="nodelabel" style="font-size:7px">NOR</text>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="36" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <!--xor -->
+  <g s:type="reduce_xor" transform="translate(350, 50)" s:width="33" s:height="25">
+    <s:alias val="$xor"/>
+    <s:alias val="$reduce_xor"/>
+    <s:alias val="$_XOR_"/>
+
+    <path d="M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+    <text x="18" y="15" class="nodelabel" style="font-size:7px">XOR</text>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="33" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="reduce_nxor" transform="translate(350, 100)" s:width="33" s:height="25">
+    <s:alias val="$xnor"/>
+    <s:alias val="$reduce_xnor"/>
+    <s:alias val="$_XNOR_"/>
+
+    <path d="M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0" class="$cell_id"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="$cell_id"/>
+    <circle cx="35" cy="12.5" r="3" class="$cell_id"/>
+    <text x="18" y="15" class="nodelabel" style="font-size:7px">XNOR</text>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="38" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <!--buffer -->
+  <g s:type="not" transform="translate(450,100)" s:width="30" s:height="20">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+
+    <path d="M0,0 L0,20 L20,10 Z" class="$cell_id"/>
+    <circle cx="23" cy="10" r="3" class="$cell_id"/>
+    <text x="8" y="12" class="nodelabel" style="font-size:6px">NOT</text>
+
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+
+  <g s:type="add" transform="translate(50, 150)" s:width="25" s:height="25">
+    <s:alias val="$add"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="12.5" class="$cell_id"/>
+    <line x1="12.5" x2="12.5" y1="7.5" y2="17.5" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="sub" transform="translate(150,150)" s:width="25" s:height="25">
+    <s:alias val="$sub"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="12.5" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="eq" transform="translate(250,150)" s:width="25" s:height="25">
+    <s:alias val="$eq"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="10" y2="10" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="15" y2="15" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="dff" transform="translate(350,150)" s:width="30" s:height="40">
+    <s:alias val="$dff"/>
+    <s:alias val="$_DFF_"/>
+    <s:alias val="$_DFF_P_"/>
+
+    <rect width="30" height="40" x="0" y="0" class="$cell_id"/>
+    <path d="M0,35 L5,30 L0,25" class="$cell_id"/>
+
+    <g s:x="30" s:y="10" s:pid="Q"/>
+    <g s:x="0" s:y="30" s:pid="CLK"/>
+    <g s:x="0" s:y="30" s:pid="C"/>
+    <g s:x="0" s:y="10" s:pid="D"/>
+  </g>
+
+  <g s:type="dffn" transform="translate(450,150)" s:width="30" s:height="40">
+    <s:alias val="$_DFF_N_"/>
+
+    <rect width="30" height="40" x="0" y="0" class="$cell_id"/>
+    <path d="M0,35 L5,30 L0,25" class="$cell_id"/>
+    <circle cx="-3" cy="30" r="3" class="$cell_id"/>
+
+    <g s:x="30" s:y="10" s:pid="Q"/>
+    <g s:x="-6" s:y="30" s:pid="CLK"/>
+    <g s:x="-6" s:y="30" s:pid="C"/>
+    <g s:x="0" s:y="10" s:pid="D"/>
+  </g>
+
+  <g s:type="lt" transform="translate(50,200)" s:width="25" s:height="25">
+    <s:alias val="$lt"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="7.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="17.5" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="le" transform="translate(150,200)" s:width="25" s:height="25">
+    <s:alias val="$le"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="7.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="17.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="15" y2="20" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="ge" transform="translate(250,200)" s:width="25" s:height="25">
+    <s:alias val="$ge"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="7.5" y2="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="17.5" y2="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="20" y2="15" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="gt" transform="translate(350,200)" s:width="25" s:height="25">
+    <s:alias val="$gt"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="7.5" y2="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="17.5" y2="12.5" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="inputExt" transform="translate(50,250)" s:width="30" s:height="20">
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">input</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="$cell_id"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+
+  <g s:type="constant" transform="translate(150,250)" s:width="30" s:height="20">
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">constant</text>
+
+    <s:alias val="$_constant_"/>
+    <rect width="30" height="20" class="$cell_id"/>
+
+    <g s:x="30" s:y="10" s:pid="Y"/>
+  </g>
+
+  <g s:type="outputExt" transform="translate(250,250)" s:width="30" s:height="20">
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">output</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="$cell_id"/>
+
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+
+  <g s:type="split" transform="translate(350,250)" s:width="5" s:height="40">
+    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
+    <s:alias val="$_split_"/>
+
+    <g s:x="0" s:y="20" s:pid="in"/>
+    <g transform="translate(5, 10)" s:x="4" s:y="10" s:pid="out0">
+      <text x="5" y="-4">hi:lo</text>
+    </g>
+    <g transform="translate(5, 30)" s:x="4" s:y="30" s:pid="out1">
+      <text x="5" y="-4">hi:lo</text>
+    </g>
+  </g>
+
+  <g s:type="join" transform="translate(450,250)" s:width="4" s:height="40">
+    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
+    <s:alias val="$_join_"/>
+    <g s:x="5" s:y="20"  s:pid="out"/>
+    <g transform="translate(0, 10)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel">hi:lo</text>
+    </g>
+    <g transform="translate(0, 30)" s:x="0" s:y="30" s:pid="in1">
+      <text x="-3" y="-4" class="inputPortLabel">hi:lo</text>
+    </g>
+  </g>
+
+  <g s:type="generic" transform="translate(550,250)" s:width="30" s:height="40">
+    <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">generic</text>
+    <rect width="30" height="40" s:generic="body" class="$cell_id"/>
+
+    <g transform="translate(30, 10)" s:x="30" s:y="10" s:pid="out0">
+      <text x="5" y="-4" style="fill:#000; stroke:none" class="$cell_id">out0</text>
+    </g>
+    <g transform="translate(30, 30)" s:x="30" s:y="30" s:pid="out1">
+      <text x="5" y="-4" style="fill:#000;stroke:none" class="$cell_id">out1</text>
+    </g>
+    <g transform="translate(0, 10)" s:x="0" s:y="10" s:pid="in0">
+      <text x="-3" y="-4" class="inputPortLabel $cell_id">in0</text>
+    </g>
+    <g transform="translate(0, 30)" s:x="0" s:y="30" s:pid="in1">
+      <text x="-3" y="-4" class="inputPortLabel $cell_id">in1</text>
+    </g>
+  </g>
+
+</svg>

--- a/basics/glossary/test/tb_glossary.v
+++ b/basics/glossary/test/tb_glossary.v
@@ -1,0 +1,109 @@
+// Verilog testbench mirror of tb_glossary.vhd.
+//
+// Same stimulus, same checks, same s-prefixed signal names so the two
+// waveforms render identically in the gallery.
+
+`timescale 1ns/1ps
+
+module tb_glossary;
+
+    reg        sClock = 1'b0;
+    reg        sA     = 1'b0;
+    reg        sB     = 1'b0;
+    reg        sSel   = 1'b0;
+    reg [1:0]  sSel4  = 2'b00;
+    reg [3:0]  sAv    = 4'b0000;
+    reg [3:0]  sBv    = 4'b0000;
+    reg        sRst   = 1'b0;
+    reg        sEn    = 1'b0;
+
+    wire       o_and, o_or, o_not, o_xor;
+    wire       o_nand, o_nor, o_xnor;
+    wire       o_reduce_or, o_reduce_and, o_reduce_xor;
+    wire       o_mux2, o_mux4;
+    wire [3:0] o_add, o_sub, o_shl, o_shr;
+    wire       o_eq, o_lt;
+    wire       o_dff, o_dffe, o_dffr;
+    wire [3:0] o_counter;
+
+    reg sSimulationActive = 1'b1;
+
+    glossary dut (
+        .a(sA), .b(sB), .sel(sSel), .sel4(sSel4),
+        .av(sAv), .bv(sBv),
+        .clk(sClock), .rst(sRst), .en(sEn),
+        .o_and(o_and), .o_or(o_or), .o_not(o_not), .o_xor(o_xor),
+        .o_nand(o_nand), .o_nor(o_nor), .o_xnor(o_xnor),
+        .o_reduce_or(o_reduce_or),
+        .o_reduce_and(o_reduce_and),
+        .o_reduce_xor(o_reduce_xor),
+        .o_mux2(o_mux2), .o_mux4(o_mux4),
+        .o_add(o_add), .o_sub(o_sub),
+        .o_eq(o_eq), .o_lt(o_lt),
+        .o_shl(o_shl), .o_shr(o_shr),
+        .o_dff(o_dff), .o_dffe(o_dffe), .o_dffr(o_dffr),
+        .o_counter(o_counter)
+    );
+
+    // 50 MHz clock — gated by sSimulationActive to mirror the VHDL TB.
+    always #10 if (sSimulationActive) sClock = ~sClock;
+
+    initial begin
+        $dumpfile(`VCD_OUT);
+        $dumpvars(1, tb_glossary);
+        $dumpvars(1, dut);
+    end
+
+    initial begin : driver
+        sA = 1'b1; sB = 1'b0; sSel = 1'b1;
+        sSel4 = 2'b10;
+        sAv = 4'b1100; sBv = 4'b0011;
+        #1;
+
+        if (o_and  !== (sA & sB))  $fatal(1, "o_and");
+        if (o_or   !== (sA | sB))  $fatal(1, "o_or");
+        if (o_not  !== ~sA)        $fatal(1, "o_not");
+        if (o_xor  !== (sA ^ sB))  $fatal(1, "o_xor");
+        if (o_nand !== ~(sA & sB)) $fatal(1, "o_nand");
+        if (o_nor  !== ~(sA | sB)) $fatal(1, "o_nor");
+        if (o_xnor !== ~(sA ^ sB)) $fatal(1, "o_xnor");
+
+        if (o_reduce_or  !== 1'b1) $fatal(1, "o_reduce_or");
+        if (o_reduce_and !== 1'b0) $fatal(1, "o_reduce_and");
+        if (o_reduce_xor !== 1'b0) $fatal(1, "o_reduce_xor");
+
+        if (o_mux2 !== sA)         $fatal(1, "o_mux2 (sel=1 -> a)");
+        if (o_mux4 !== sAv[2])     $fatal(1, "o_mux4 (sel4=10 -> av[2])");
+
+        if (o_add !== 4'b1111)     $fatal(1, "o_add (12+3=15)");
+        if (o_sub !== 4'b1001)     $fatal(1, "o_sub (12-3=9)");
+        if (o_eq  !== 1'b0)        $fatal(1, "o_eq");
+        if (o_lt  !== 1'b0)        $fatal(1, "o_lt (12<3 false)");
+        if (o_shl !== 4'b1000)     $fatal(1, "o_shl (1100<<1)");
+        if (o_shr !== 4'b0110)     $fatal(1, "o_shr (1100>>1)");
+
+        sRst = 1'b0; sEn = 1'b1;
+        @(posedge sClock); #1;
+        if (o_dff     !== 1'b1)    $fatal(1, "o_dff after first edge");
+        if (o_dffe    !== 1'b1)    $fatal(1, "o_dffe after first edge with en=1");
+        if (o_dffr    !== 1'b1)    $fatal(1, "o_dffr after first edge no rst");
+        if (o_counter !== 4'b0001) $fatal(1, "o_counter after first edge");
+
+        sA = 1'b0; sEn = 1'b0;
+        @(posedge sClock); #1;
+        if (o_dff     !== 1'b0)    $fatal(1, "o_dff after second edge (a=0)");
+        if (o_dffe    !== 1'b1)    $fatal(1, "o_dffe must hold when en=0");
+        if (o_dffr    !== 1'b0)    $fatal(1, "o_dffr after second edge (a=0)");
+        if (o_counter !== 4'b0010) $fatal(1, "o_counter after second edge");
+
+        sRst = 1'b1;
+        @(posedge sClock); #1;
+        if (o_dffr    !== 1'b0)    $fatal(1, "o_dffr after rst");
+        if (o_counter !== 4'b0000) $fatal(1, "o_counter after rst");
+
+        $display("Simulation done!");
+        sSimulationActive = 1'b0;
+        $finish;
+    end
+
+endmodule

--- a/basics/glossary/test/tb_glossary.vhd
+++ b/basics/glossary/test/tb_glossary.vhd
@@ -1,0 +1,135 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity tb_glossary is
+end entity tb_glossary;
+
+architecture testbench of tb_glossary is
+    signal sSimulationActive : boolean   := true;
+    signal sClock            : std_logic := '0';
+
+    signal sA, sB, sSel : std_logic := '0';
+    signal sSel4        : std_logic_vector(1 downto 0) := "00";
+    signal sAv, sBv     : std_logic_vector(3 downto 0) := (others => '0');
+    signal sRst, sEn    : std_logic := '0';
+
+    signal o_and, o_or, o_not, o_xor                  : std_logic;
+    signal o_nand, o_nor, o_xnor                      : std_logic;
+    signal o_reduce_or, o_reduce_and, o_reduce_xor    : std_logic;
+    signal o_mux2, o_mux4                             : std_logic;
+    signal o_add, o_sub, o_shl, o_shr                 : std_logic_vector(3 downto 0);
+    signal o_eq, o_lt                                 : std_logic;
+    signal o_dff, o_dffe, o_dffr                      : std_logic;
+    signal o_counter                                  : std_logic_vector(3 downto 0);
+begin
+
+    DUT : entity work.glossary(rtl)
+        port map (
+            a    => sA,
+            b    => sB,
+            sel  => sSel,
+            sel4 => sSel4,
+            av   => sAv,
+            bv   => sBv,
+            clk  => sClock,
+            rst  => sRst,
+            en   => sEn,
+
+            o_and  => o_and,
+            o_or   => o_or,
+            o_not  => o_not,
+            o_xor  => o_xor,
+            o_nand => o_nand,
+            o_nor  => o_nor,
+            o_xnor => o_xnor,
+
+            o_reduce_or  => o_reduce_or,
+            o_reduce_and => o_reduce_and,
+            o_reduce_xor => o_reduce_xor,
+
+            o_mux2 => o_mux2,
+            o_mux4 => o_mux4,
+
+            o_add => o_add,
+            o_sub => o_sub,
+            o_eq  => o_eq,
+            o_lt  => o_lt,
+            o_shl => o_shl,
+            o_shr => o_shr,
+
+            o_dff     => o_dff,
+            o_dffe    => o_dffe,
+            o_dffr    => o_dffr,
+            o_counter => o_counter
+        );
+
+    -- 50 MHz clock (20 ns period); only ticks while sim is active.
+    sClock <= not sClock after 10 ns when sSimulationActive;
+
+    CHECK : process is
+    begin
+        -- Combinational block: drive a representative pattern, settle, check.
+        sA    <= '1';
+        sB    <= '0';
+        sSel  <= '1';
+        sSel4 <= "10";
+        sAv   <= "1100";  -- 12
+        sBv   <= "0011";  -- 3
+        wait for 1 ns;
+
+        assert o_and  = (sA and  sB)  report "o_and"  severity error;
+        assert o_or   = (sA or   sB)  report "o_or"   severity error;
+        assert o_not  = (not sA)      report "o_not"  severity error;
+        assert o_xor  = (sA xor  sB)  report "o_xor"  severity error;
+        assert o_nand = (sA nand sB)  report "o_nand" severity error;
+        assert o_nor  = (sA nor  sB)  report "o_nor"  severity error;
+        assert o_xnor = (sA xnor sB)  report "o_xnor" severity error;
+
+        assert o_reduce_or  = '1' report "o_reduce_or"  severity error;
+        assert o_reduce_and = '0' report "o_reduce_and" severity error;
+        assert o_reduce_xor = '0' report "o_reduce_xor" severity error;
+
+        assert o_mux2 = sA      report "o_mux2 (sel=1 -> a)" severity error;
+        assert o_mux4 = sAv(2)  report "o_mux4 (sel4=10 -> av(2))" severity error;
+
+        assert o_add = "1111" report "o_add (12+3=15)"  severity error;
+        assert o_sub = "1001" report "o_sub (12-3=9)"   severity error;
+        assert o_eq  = '0'    report "o_eq"             severity error;
+        assert o_lt  = '0'    report "o_lt (12<3 false)" severity error;
+        assert o_shl = "1000" report "o_shl (1100<<1)"  severity error;
+        assert o_shr = "0110" report "o_shr (1100>>1)"  severity error;
+
+        -- Sequential block: load a=1, en=1, rst=0 across the first edge.
+        sRst <= '0';
+        sEn  <= '1';
+        wait until rising_edge(sClock);
+        wait for 1 ns;
+        assert o_dff     = '1'    report "o_dff after first edge"             severity error;
+        assert o_dffe    = '1'    report "o_dffe after first edge with en=1"  severity error;
+        assert o_dffr    = '1'    report "o_dffr after first edge no rst"     severity error;
+        assert o_counter = "0001" report "o_counter after first edge"         severity error;
+
+        -- Disable enable, change a: dffe must freeze, dff/dffr follow a, counter ticks.
+        sA  <= '0';
+        sEn <= '0';
+        wait until rising_edge(sClock);
+        wait for 1 ns;
+        assert o_dff     = '0'    report "o_dff after second edge (a=0)"      severity error;
+        assert o_dffe    = '1'    report "o_dffe must hold when en=0"         severity error;
+        assert o_dffr    = '0'    report "o_dffr after second edge (a=0)"     severity error;
+        assert o_counter = "0010" report "o_counter after second edge"        severity error;
+
+        -- Synchronous reset: dffr and counter clear; dff still tracks a.
+        sRst <= '1';
+        wait until rising_edge(sClock);
+        wait for 1 ns;
+        assert o_dffr    = '0'    report "o_dffr after rst"      severity error;
+        assert o_counter = "0000" report "o_counter after rst"   severity error;
+
+        report "Simulation done!" severity note;
+        sSimulationActive <= false;
+        wait;
+    end process CHECK;
+
+end architecture testbench;


### PR DESCRIPTION
## Summary

- New `glossary/` project: a flat top-level module that drives one of every basic primitive in the synthesised netlist so each gets its own cell with no neighbouring fan-in/fan-out — the diagram is a one-glance legend you can cross-reference against any other netlist in the [Gallery](../README.md#gallery).
- Coverage: bitwise gates (and / or / not / xor / nand / nor / xnor), vector reductions (or / and / xor over a 4-bit bus), 2:1 and 4:1 muxes, arithmetic (add / sub), comparators (eq / lt), shifters (shl / shr), three D flip-flop variants (plain / clock-enable / sync-reset), and a 4-bit counter.
- VHDL + Verilog mirrors with identical port shape; `tb_glossary` (both languages) drives one representative pattern through the combinational outputs and three rising clock edges through the sequential ones, asserting the truth/characteristic-table row that gets exercised.
- `glossary/README.md` ships truth tables for every combinational cell, behaviour tables for every sequential one, and a group-by-group summary of the netlistsvg shapes you'll see in the rendered diagram.
- Top-level README updated: new entry placed first in the Gallery (open by default — it's the legend), and a row added at the top of the project table.

## Test plan

- [x] `make -C glossary clean && make -C glossary` runs cleanly in `ghcr.io/naelolaiz/hdltools:release` — both flows produce `glossary.svg` / `glossary_v.svg` netlists, `tb_glossary.png` / `tb_glossary_v.png` waveforms, and both testbenches print `Simulation done!`.
- [x] `make list` at the repo root auto-discovers `./glossary` (no manual registration needed).
- [ ] CI on this PR renders the netlist + waveform images in the per-job summary and PR comment, and the inline gallery links resolve once `main` mirrors them.