### PR TITLE
mk: switch all simulation dumps to FST (GHDL + iverilog)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           name: ${{ steps.artifact.outputs.name }}-artifacts
           path: |
-            ${{ matrix.project }}/build/*.vcd
+            ${{ matrix.project }}/build/*.fst
             ${{ matrix.project }}/build/*.svg
             ${{ matrix.project }}/build/*.json
             ${{ matrix.project }}/build/*.png
@@ -234,7 +234,7 @@ jobs:
             proj=$(basename "$art" | sed 's/-artifacts$//')
             dest="$stage/run-${GITHUB_RUN_ID}/$proj"
             mkdir -p "$dest"
-            # Copy only the visual outputs; skip the huge VCDs.
+            # Copy only the visual outputs; skip the FST dumps.
             copied=0
             for f in "$art"/*.svg "$art"/*.png; do
               [ -f "$f" ] || continue

--- a/.github/workflows/release_tags.yml
+++ b/.github/workflows/release_tags.yml
@@ -1,9 +1,9 @@
 name: release_tags
 
 # Builds every project end-to-end (simulate + diagram + waveform) using
-# the same Makefile targets CI uses, collects the generated VCDs, PNGs,
-# SVGs and JSON netlists into a single zip, and publishes a GitHub
-# Release when a tag is pushed.
+# the same Makefile targets CI uses, collects the generated FST dumps,
+# PNGs, SVGs and JSON netlists into a single zip, and publishes a
+# GitHub Release when a tag is pushed.
 
 on:
   push:
@@ -55,8 +55,8 @@ jobs:
       - name: Collect artifacts
         run: |
           set -e
-          mkdir -p release/vcd release/svg release/png release/json
-          find . -path '*/build/*.vcd'  -exec cp {} release/vcd/  \;
+          mkdir -p release/fst release/svg release/png release/json
+          find . -path '*/build/*.fst'  -exec cp {} release/fst/  \;
           find . -path '*/build/*.svg'  -exec cp {} release/svg/  \;
           find . -path '*/build/*.png'  -exec cp {} release/png/  \;
           find . -path '*/build/*.json' -exec cp {} release/json/ \;

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ work/
 work-obj*.cf
 *.cf
 *.o
-*.vcd
 *.ghw
 *.fst
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@
    # TB_TOPS is a space-separated list. Projects with a single
    # testbench write a one-entry list; projects that have multiple
    # focused testbenches (e.g. unit vs. integration) list them all and
-   # each one renders its own VCD + PNG in `build/`.
+   # each one renders its own FST + PNG in `build/`.
    TB_TOPS := tb_my_top
 
    SRC_FILES := my_top.vhd
@@ -42,16 +42,20 @@
    include ../../mk/common.mk    # adjust ../ depth to your project's nesting
    ```
 
-   For Verilog testbenches, dump waveforms via the supplied `VCD_OUT`
+   For Verilog testbenches, dump waveforms via the supplied `FST_OUT`
    define so the file lands in `build/`:
 
    ```verilog
    initial begin
-       $dumpfile(`VCD_OUT);
+       $dumpfile(`FST_OUT);
        $dumpvars(0, tb_my_top);
        // ...
    end
    ```
+
+   The Makefile runs `vvp` with `IVERILOG_DUMPER=fst`, so iverilog 13
+   emits FST natively — no testbench-side change needed beyond the
+   filename extension.
 
 3. Build locally:
 
@@ -66,7 +70,7 @@
 - Projects live under a category subdirectory (`basics/`, `building_blocks/`,
   `display/`, `comm/`, `tools/`). The categorisation is informal — pick
   the one that fits, or propose a new bucket in the PR description.
-- The VHDL work library, VCDs, PNGs, SVGs and JSON netlists all land in
+- The VHDL work library, FST dumps, PNGs, SVGs and JSON netlists all land in
   `build/` under the project directory. `make clean` is a single `rm -rf`.
 - Paths in `SRC_FILES` / `TB_FILES` are relative to the `Makefile`. That's
   why the testbench in a `test/` subdir is listed as `test/tb_*.vhd`.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 	@echo "  all         simulate + diagram + waveform"
 	@echo "  analyze     ghdl -a"
 	@echo "  elaborate   ghdl -e"
-	@echo "  simulate    ghdl -r (emits a VCD)"
+	@echo "  simulate    ghdl -r (emits an FST)"
 	@echo "  diagram     yosys + netlistsvg (emits an SVG)"
 	@echo "  waveform    waveview render (emits an SVG + PNG)"
 	@echo "  clean       remove every build/ directory"

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Three focused testbenches: `tb_trigonometric` (integration sweep + rotate proper
 ### Tools
 
 <details>
-<summary><b><code>simulator_writer</code></b> — produces a VCD trace for the simulator flow</summary>
+<summary><b><code>simulator_writer</code></b> — produces a waveform trace for the simulator flow</summary>
 
 | | VHDL | Verilog |
 | --- | :---: | :---: |
@@ -340,9 +340,9 @@ any `Makefile` that includes `mk/common.mk`.
 
 | Stage        | Tool chain                                        | Output                          |
 | ------------ | ------------------------------------------------- | ------------------------------- |
-| simulate     | GHDL (VHDL) / iverilog (Verilog)                  | `build/<tb>.vcd`                |
+| simulate     | GHDL (VHDL) / iverilog (Verilog)                  | `build/<tb>.fst`                |
 | diagram      | yosys + ghdl-yosys-plugin → netlistsvg            | `build/<top>.svg`               |
-| waveform     | VCD/FST → waveview                                | `build/<tb>.svg`, `build/<tb>.png` |
+| waveform     | FST → waveview                                    | `build/<tb>.svg`, `build/<tb>.png` |
 
 Each matrix job:
 
@@ -382,18 +382,19 @@ Swap `podman` for `docker` if that is your local runtime.
 The build machinery is **bilingual**. A project that defines `V_TOP` /
 `V_TB_TOPS` / `V_SRC_FILES` / `V_TB_FILES` in its `Makefile` also gets a
 parallel iverilog / yosys flow whose artifacts share `build/` with the
-VHDL ones via a `_v` suffix (`build/<top>_v.svg`, `build/<tb>_v.vcd`,
+VHDL ones via a `_v` suffix (`build/<top>_v.svg`, `build/<tb>_v.fst`,
 `build/<tb>_v.png`) — both languages coexist without colliding.
 
 | target         | tooling                              |
 | -------------- | ------------------------------------ |
-| `simulate_v`   | `iverilog -g2012` → `vvp`            |
+| `simulate_v`   | `iverilog -g2012` → `vvp` (FST)      |
 | `diagram_v`    | `yosys read_verilog` → `netlistsvg`  |
-| `waveform_v`   | `vvp` VCD → waveview                 |
+| `waveform_v`   | FST → waveview                       |
 
 `make all` runs both flows when both language sets are populated.
-Verilog testbenches must call `` $dumpfile(`VCD_OUT) `` — the Makefile
-supplies that define so the dump file always lands in `build/`. See
+Verilog testbenches must call `` $dumpfile(`FST_OUT) `` — the Makefile
+supplies that define so the dump file always lands in `build/`, and
+runs `vvp` with `IVERILOG_DUMPER=fst` so iverilog 13 emits FST. See
 [blink_led/test/tb_blink_led.v](basics/blink_led/test/tb_blink_led.v) for the
 canonical pattern.
 
@@ -453,7 +454,7 @@ Projects are grouped by intent. Legend: ✅ built in CI · ⏳ pending adoption 
 
 | Project | CI | Languages | Notes |
 | --- | :-: | --- | --- |
-| [simulator_writer](tools/simulator_writer/) | ✅ | VHDL + Verilog | VCD writer used to sanity-check the sim flow. |
+| [simulator_writer](tools/simulator_writer/) | ✅ | VHDL + Verilog | Waveform writer used to sanity-check the sim flow. |
 
 ---
 

--- a/basics/blink_led/test/tb_blink_led.v
+++ b/basics/blink_led/test/tb_blink_led.v
@@ -20,7 +20,7 @@ module tb_blink_led;
     always #10 if (sSimulationActive) sClock50MHz = ~sClock50MHz;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_blink_led);
         $dumpvars(1, dut);
     end

--- a/basics/blink_led/test/tb_blink_led_minimal.v
+++ b/basics/blink_led/test/tb_blink_led_minimal.v
@@ -18,7 +18,7 @@ module tb_blink_led_minimal;
     always #10 if (sSimulationActive) sClock50MHz = ~sClock50MHz;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_blink_led_minimal);
         $dumpvars(1, dut);
     end

--- a/basics/glossary/test/tb_glossary.v
+++ b/basics/glossary/test/tb_glossary.v
@@ -49,7 +49,7 @@ module tb_glossary;
     always #10 if (sSimulationActive) sClock = ~sClock;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_glossary);
         $dumpvars(1, dut);
     end

--- a/basics/logic_styles/test/tb_logic_styles.v
+++ b/basics/logic_styles/test/tb_logic_styles.v
@@ -43,7 +43,7 @@ module tb_logic_styles;
     always #10 if (sSimulationActive) sClock = ~sClock;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_logic_styles);
         $dumpvars(1, dut);
     end

--- a/basics/pwm_led/test/tb_pwm_led.v
+++ b/basics/pwm_led/test/tb_pwm_led.v
@@ -22,7 +22,7 @@ module tb_pwm_led;
     always #(CLK_PERIOD/2) if (sSimulationActive) sClk = ~sClk;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_pwm_led);
         $dumpvars(1, dut);
     end

--- a/building_blocks/debounce/test/tb_debounce_bounce.v
+++ b/building_blocks/debounce/test/tb_debounce_bounce.v
@@ -44,7 +44,7 @@ module tb_debounce_bounce;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_debounce_bounce);
         $dumpvars(1, dut);
     end

--- a/building_blocks/debounce/test/tb_debounce_glitch.v
+++ b/building_blocks/debounce/test/tb_debounce_glitch.v
@@ -34,7 +34,7 @@ module tb_debounce_glitch;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_debounce_glitch);
         $dumpvars(1, dut);
     end

--- a/building_blocks/fifo_sync/test/tb_fifo_sync.v
+++ b/building_blocks/fifo_sync/test/tb_fifo_sync.v
@@ -40,9 +40,9 @@ module tb_fifo_sync;
 
     // Level 1 restricts the dump to the TB's own top-level signals and
     // the DUT's top-level signals — loop counters inside `driver` and
-    // any function-local hierarchy stay hidden, matching GHDL's VCD.
+    // any function-local hierarchy stay hidden, matching GHDL's FST dump.
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_fifo_sync);
         $dumpvars(1, dut);
     end

--- a/building_blocks/fifo_sync/test/tb_fifo_sync_overlapping.v
+++ b/building_blocks/fifo_sync/test/tb_fifo_sync_overlapping.v
@@ -49,7 +49,7 @@ module tb_fifo_sync_overlapping;
     always #(CLK_PERIOD/2) if (sSimulationActive) sClk = ~sClk;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_fifo_sync_overlapping);
         $dumpvars(1, dut);
     end

--- a/building_blocks/random_generator/Makefile
+++ b/building_blocks/random_generator/Makefile
@@ -6,11 +6,9 @@ TB_TOPS := tb_random_generator tb_random_generator_long
 SRC_FILES := random_generator.vhd neoTRNG.vhd
 TB_FILES  := test/tb_random_generator.vhd test/tb_random_generator_long.vhd
 
-# tb_random_generator_long runs for 12 ms; FST keeps the dump small,
-# and the per-clock-edge waveform is unreadable at this zoom anyway.
-# Assertions still gate CI through GHDL's --assert-level=error.
-FST_TBS := tb_random_generator_long
-
+# tb_random_generator_long runs for 12 ms; the per-clock-edge waveform
+# is unreadable at this zoom, so skip the waveform render. Assertions
+# still gate CI through GHDL's --assert-level=error.
 NO_WAVEFORM_TBS   := tb_random_generator_long
 V_NO_WAVEFORM_TBS := tb_random_generator_long
 

--- a/building_blocks/random_generator/test/tb_random_generator.v
+++ b/building_blocks/random_generator/test/tb_random_generator.v
@@ -96,7 +96,7 @@ module tb_random_generator;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_random_generator);
         $dumpvars(1, dut);
     end

--- a/building_blocks/random_generator/test/tb_random_generator_long.v
+++ b/building_blocks/random_generator/test/tb_random_generator_long.v
@@ -79,7 +79,7 @@ module tb_random_generator_long;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_random_generator_long);
         $dumpvars(1, dut);
     end

--- a/building_blocks/serial_to_parallel/test/tb_serial_to_parallel_basic.v
+++ b/building_blocks/serial_to_parallel/test/tb_serial_to_parallel_basic.v
@@ -27,7 +27,7 @@ module tb_serial_to_parallel_basic;
     always #10 if (sSimulationActive) sClock = ~sClock;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_serial_to_parallel_basic);
         $dumpvars(1, dut);
     end

--- a/building_blocks/serial_to_parallel/test/tb_serial_to_parallel_print_gating.v
+++ b/building_blocks/serial_to_parallel/test/tb_serial_to_parallel_print_gating.v
@@ -40,7 +40,7 @@ module tb_serial_to_parallel_print_gating;
     endtask
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_serial_to_parallel_print_gating);
         $dumpvars(1, dut);
     end

--- a/building_blocks/shift_register/test/tb_shift_register.v
+++ b/building_blocks/shift_register/test/tb_shift_register.v
@@ -31,7 +31,7 @@ module tb_shift_register;
     always #(CLK_PERIOD/2) if (sSimulationActive) sClk = ~sClk;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_shift_register);
         $dumpvars(1, dut);
     end

--- a/comm/uart_tx/test/tb_uart_tx.v
+++ b/comm/uart_tx/test/tb_uart_tx.v
@@ -29,7 +29,7 @@ module tb_uart_tx;
     always #(CLK_PERIOD/2) if (sSimulationActive) sClk = ~sClk;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_uart_tx);
         $dumpvars(1, dut);
     end

--- a/comm/uart_tx/uart_tx.vhd
+++ b/comm/uart_tx/uart_tx.vhd
@@ -28,8 +28,9 @@ entity uart_tx is
 end entity uart_tx;
 
 architecture rtl of uart_tx is
-  -- `state` is an encoded vector (not an enum) so GHDL dumps it to the
-  -- VCD and the Verilog + VHDL waveforms carry the same signal set.
+  -- `state` is an encoded vector (not an enum) so GHDL surfaces it in
+  -- the FST dump and the Verilog + VHDL waveforms carry the same
+  -- signal set.
   constant S_IDLE  : std_logic_vector(1 downto 0) := "00";
   constant S_START : std_logic_vector(1 downto 0) := "01";
   constant S_DATA  : std_logic_vector(1 downto 0) := "10";

--- a/display/7segments/clock/test/tb_clock_alarm.v
+++ b/display/7segments/clock/test/tb_clock_alarm.v
@@ -25,7 +25,7 @@ module tb_clock_alarm;
     );
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_clock_alarm);
         $dumpvars(1, dut);
     end

--- a/display/7segments/clock/test/tb_clock_dot_blink.v
+++ b/display/7segments/clock/test/tb_clock_dot_blink.v
@@ -31,7 +31,7 @@ module tb_clock_dot_blink;
     );
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_clock_dot_blink);
         $dumpvars(1, dut);
     end

--- a/display/7segments/counter/Makefile
+++ b/display/7segments/counter/Makefile
@@ -13,12 +13,6 @@ TB_TOPS := tb_counter tb_counter_long
 SRC_FILES := counter.vhd
 TB_FILES  := test/tb_counter.vhd test/tb_counter_long.vhd
 
-# A 150 ms sim at GHDL's 1 fs timescale produces a ~650 MB VCD;
-# dumping in FST format instead keeps the file small without
-# coarsening any timestamps we care about. waveview reads FST
-# natively.
-FST_TBS := tb_counter_long
-
 # tb_counter_long's value is its counter-tick assertion, not its
 # waveform: at 150 ms the 20 ns clock period is sub-pixel in any
 # raster render. Skip the waveform render; simulate still runs and

--- a/display/7segments/counter/test/tb_counter.v
+++ b/display/7segments/counter/test/tb_counter.v
@@ -19,7 +19,7 @@ module tb_counter;
     // Shorter than the VHDL TB (150 ms) but long enough to rotate
     // through all four digits: mux period is 2 ms at 50 MHz, so
     // 10 ms covers one full rotation and the start of the next.
-    // Keeps iverilog's runtime + VCD size manageable in CI.
+    // Keeps iverilog's runtime + FST size manageable in CI.
     localparam time TEST_DURATION = 10_000_000;  // 10 ms in ns
     reg        sClock50MHz   = 1'b0;
     wire [6:0] sSevenSegments;
@@ -104,7 +104,7 @@ module tb_counter;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_counter);
         $dumpvars(1, dut);
     end

--- a/display/7segments/counter/test/tb_counter.vhd
+++ b/display/7segments/counter/test/tb_counter.vhd
@@ -30,9 +30,8 @@ end tb_counter;
 architecture testbench of tb_counter is
    -- 10 ms covers a full mux rotation (2 ms per digit -> 8 ms for
    -- 0->1->2->3) and a bit more, which is all the assertions need.
-   -- Keep this short: GHDL dumps at 1 fs timescale by default, so
-   -- long runs produce multi-hundred-MB VCDs that the gallery's
-   -- waveform render pipeline can't process in time.
+   -- The companion tb_counter_long covers slower behaviour over a
+   -- 150 ms window where the per-clock waveform is sub-pixel anyway.
    constant TEST_DURATION : time := 10 ms;
    signal sClock50MHz       : std_logic := '0';
    -- Initialise to a valid encoding so the continuous invariants

--- a/display/7segments/counter/test/tb_counter_long.v
+++ b/display/7segments/counter/test/tb_counter_long.v
@@ -8,7 +8,7 @@
 // No PNG is generated for this testbench (see V_NO_PNG_TBS in the
 // Makefile): at 150 ms the 20 ns clock period is sub-pixel in the
 // gallery image anyway, and the TB's value is its assertion, not
-// its waveform. The VCD still dumps (to keep the flow uniform) and
+// its waveform. The FST still dumps (to keep the flow uniform) and
 // the assertion guards CI via the $fatal exit code.
 //
 // Assertion:
@@ -49,7 +49,7 @@ module tb_counter_long;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_counter_long);
         $dumpvars(1, dut);
     end

--- a/display/7segments/counter/test/tb_counter_long.vhd
+++ b/display/7segments/counter/test/tb_counter_long.vhd
@@ -10,9 +10,8 @@ use ieee.numeric_std.ALL;
 -- ticks every ~62.5 ms — is observed incrementing.
 --
 -- At 1 fs GHDL timescale a 150 ms VCD would be ~650 MB (too large for
--- the waveform render pipeline). Dumped in FST format instead via
--- `FST_TBS := tb_counter_long` in the Makefile; waveview reads FST
--- natively, so the rest of the flow is unchanged.
+-- the waveform render pipeline). FST keeps the dump small; waveview
+-- reads FST natively, so the rest of the flow is unchanged.
 --
 -- Assertion added on top of the tb_counter three:
 --   (D) By end-of-sim, the internal counter must have incremented

--- a/display/7segments/text/Makefile
+++ b/display/7segments/text/Makefile
@@ -7,13 +7,10 @@ SRC_FILES := text.vhd
 TB_FILES  := test/tb_text.vhd test/tb_text_long.vhd
 
 # tb_text_long runs for 40 ms with the scroll period compressed to
-# 5 ms (SCROLL_MAX generic override). The VCD would still be large
-# at 1 fs GHDL timescale; FST keeps it small. Skip the waveform
-# render for the same reason as counter's long TB — the per-pixel
-# clock-edge waveform is meaningless at this zoom, and the
-# assertions are what guards CI.
-FST_TBS := tb_text_long
-
+# 5 ms (SCROLL_MAX generic override). Skip the waveform render for
+# the same reason as counter's long TB — the per-pixel clock-edge
+# waveform is meaningless at this zoom, and the assertions are what
+# guards CI.
 NO_WAVEFORM_TBS   := tb_text_long
 V_NO_WAVEFORM_TBS := tb_text_long
 

--- a/display/7segments/text/test/tb_text.v
+++ b/display/7segments/text/test/tb_text.v
@@ -77,7 +77,7 @@ module tb_text;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_text);
         $dumpvars(1, dut);
     end

--- a/display/7segments/text/test/tb_text.vhd
+++ b/display/7segments/text/test/tb_text.vhd
@@ -6,7 +6,7 @@ use ieee.numeric_std.all;
 --
 -- 10 ms run with inputButtons all-high (no scroll-pause) - long
 -- enough to see the mux rotate through every digit at 2 ms/digit
--- (~8 ms full rotation), short enough to keep the VCD small for the
+-- (~8 ms full rotation), short enough to keep the dump small for the
 -- gallery PNG.
 --
 -- Asserts:

--- a/display/7segments/text/test/tb_text_long.v
+++ b/display/7segments/text/test/tb_text_long.v
@@ -77,7 +77,7 @@ module tb_text_long;
     end
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_text_long);
         $dumpvars(1, dut);
     end

--- a/display/7segments/text/test/tb_text_long.vhd
+++ b/display/7segments/text/test/tb_text_long.vhd
@@ -22,9 +22,9 @@ use ieee.numeric_std.all;
 --           offset constant: every sample of digit 0 in this phase
 --           must equal the latched value from the start of the phase.
 --
--- This TB pairs with FST_TBS / NO_WAVEFORM_TBS in the Makefile: the
--- VCD would be large at 40 ms and unreadable when rendered, but the
--- assertions still gate CI via GHDL's --assert-level=error.
+-- This TB pairs with NO_WAVEFORM_TBS in the Makefile: the dump would
+-- be unreadable when rendered at 40 ms, but the assertions still
+-- gate CI via GHDL's --assert-level=error.
 
 entity tb_text_long is
 end tb_text_long;

--- a/display/vga_sprites/Makefile
+++ b/display/vga_sprites/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME := vga_sprites
 
-# Three focused testbenches, each renders its own VCD + PNG in CI:
+# Three focused testbenches, each renders its own FST + PNG in CI:
 #   tb_trigonometric      integration sweep + algebraic property checks
 #                         on the rotate() function and LUT.
 #   tb_multiply_by_sin_lut unit tests for the multiplyBySinLUT primitive.

--- a/display/vga_sprites/test/tb_multiply_by_sin_lut.v
+++ b/display/vga_sprites/test/tb_multiply_by_sin_lut.v
@@ -45,7 +45,7 @@ module tb_multiply_by_sin_lut;
     endfunction
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_multiply_by_sin_lut);
     end
 

--- a/display/vga_sprites/test/tb_sprite_gravity.v
+++ b/display/vga_sprites/test/tb_sprite_gravity.v
@@ -58,11 +58,11 @@ module tb_sprite_gravity;
 
     // VHDL's sprite process variables (counters, nextPositionToTest,
     // currentSpeed, collisionDetected, indexForSpriteRotation, etc.) do
-    // not appear in GHDL's VCD. sprite.v keeps them as module-scope regs
+    // not appear in GHDL's FST dump. sprite.v keeps them as module-scope regs
     // for yosys compatibility — list the signals we actually want dumped
     // here so the waveform matches the VHDL twin.
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_sprite_gravity);
         $dumpvars(0, dut.inClock, dut.inEnabled, dut.inColision,
                      dut.outShouldDraw,

--- a/display/vga_sprites/test/tb_trigonometric.v
+++ b/display/vga_sprites/test/tb_trigonometric.v
@@ -36,7 +36,7 @@ module tb_trigonometric;
     localparam integer SPRITE_SIZE_CHECK_H = 11;
 
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_trigonometric);
     end
 

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -6,7 +6,7 @@
 #   PROJECT_NAME   Identifier used for artifact names and logs.
 #   TOP            Top-level entity (used for diagram synthesis).
 #   TB_TOPS        Space-separated list of testbench top-levels. Each
-#                  produces its own `build/<tb>.vcd` and
+#                  produces its own `build/<tb>.fst` and
 #                  `build/<tb>.png`. Projects with a single testbench
 #                  write `TB_TOPS := tb_foo` (one entry).
 #   SRC_FILES      VHDL sources of the design, relative to the Makefile.
@@ -28,7 +28,7 @@
 #
 #   V_TOP          Verilog top-level module name (for diagram synthesis).
 #   V_TB_TOPS      Space-separated list of Verilog testbench top modules.
-#                  One VCD + PNG is produced per entry, suffixed with `_v`.
+#                  One FST + PNG is produced per entry, suffixed with `_v`.
 #   V_SRC_FILES    Verilog sources of the design.
 #   V_TB_FILES     Verilog sources of every testbench.
 #   V_DEFINES      Extra `-D` macros for iverilog/yosys (e.g. WIDTH=8).
@@ -43,16 +43,20 @@
 # Artifact locations (all under build/ for trivial `make clean`):
 #
 #   build/work/                  GHDL work library
-#   build/<tb>.vcd               VHDL simulation waveform dump (one per TB_TOPS entry)
+#   build/<tb>.fst               VHDL simulation waveform dump (one per TB_TOPS entry)
 #   build/<tb>.svg               VHDL waveform diagram, vector (one per TB_TOPS entry)
 #   build/<tb>.png               VHDL waveform diagram, raster (one per TB_TOPS entry)
 #   build/<TOP>.json             VHDL synthesised netlist
 #   build/<TOP>.svg              VHDL netlist diagram
-#   build/<tb>_v.vcd             Verilog simulation waveform (one per V_TB_TOPS entry)
+#   build/<tb>_v.fst             Verilog simulation waveform (one per V_TB_TOPS entry)
 #   build/<tb>_v.svg             Verilog waveform diagram, vector (one per V_TB_TOPS entry)
 #   build/<tb>_v.png             Verilog waveform diagram, raster (one per V_TB_TOPS entry)
 #   build/<V_TOP>_v.json         Verilog synthesised netlist
 #   build/<V_TOP>_v.svg          Verilog netlist diagram
+#
+# Both the GHDL and iverilog flows dump FST natively — GHDL via `--fst=`,
+# iverilog via `IVERILOG_DUMPER=fst` at vvp runtime. FST is ~10-100x
+# smaller than VCD on long-window TBs and is what waveview reads anyway.
 # ---------------------------------------------------------------------------
 
 # ---- Tool discovery (overridable from the environment) --------------------
@@ -79,13 +83,6 @@ EXTRA_GHDL    ?=
 GHDL_SYNTH_EXTRA ?=
 SKIP_DIAGRAM  ?=
 SKIP_WAVEFORM ?=
-# Per-TB opt-in to FST dump format (GHDL --fst) instead of VCD.
-# FST is ~10-100x smaller; use for long-window testbenches where the
-# VCD would be many hundreds of MB. waveview reads FST natively, but
-# very long timelines often render to a sub-pixel-per-edge waveform —
-# pair with NO_WAVEFORM_TBS (see below) when the dump is interesting
-# only for its assertions.
-FST_TBS       ?=
 # Per-TB opt-out of the `waveform` step. Use when a testbench's
 # contribution is its assertions, not its waveform — e.g. a
 # long-window TB whose waveform would be sub-pixel-per-clock-edge
@@ -144,21 +141,20 @@ COMMON_MK_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # ---- Layout ----------------------------------------------------------------
 BUILD_DIR     := build
 WORK_DIR      := $(BUILD_DIR)/work
-# Waveform path for a given testbench. VHDL TBs in FST_TBS dump FST
-# (GHDL --fst=); everything else is VCD.
-tb_wave   = $(BUILD_DIR)/$(1)$(if $(filter $(1),$(FST_TBS)),.fst,.vcd)
-v_tb_wave = $(BUILD_DIR)/$(1)_v.vcd
+# Waveform path for a given testbench. Both flows dump FST.
+tb_wave   = $(BUILD_DIR)/$(1).fst
+v_tb_wave = $(BUILD_DIR)/$(1)_v.fst
 
 # Per-TB artifact lists. The netlist is still singular (it's the design
 # top-level, not a testbench), but simulation/waveform fan out over
 # $(TB_TOPS) / $(V_TB_TOPS). TBs in NO_WAVEFORM_TBS contribute to simulate
 # (their assertions run) but are excluded from the waveform output.
-VCD_FILES     := $(foreach tb,$(TB_TOPS),$(call tb_wave,$(tb)))
+WAVE_FILES    := $(foreach tb,$(TB_TOPS),$(call tb_wave,$(tb)))
 WAVEFORM_PNGS := $(foreach tb,$(filter-out $(NO_WAVEFORM_TBS),$(TB_TOPS)),$(BUILD_DIR)/$(tb).png)
 NETLIST_JSON  := $(BUILD_DIR)/$(TOP).json
 DIAGRAM_SVG   := $(BUILD_DIR)/$(TOP).svg
 
-V_VCD_FILES     := $(foreach tb,$(V_TB_TOPS),$(call v_tb_wave,$(tb)))
+V_WAVE_FILES    := $(foreach tb,$(V_TB_TOPS),$(call v_tb_wave,$(tb)))
 V_WAVEFORM_PNGS := $(foreach tb,$(filter-out $(V_NO_WAVEFORM_TBS),$(V_TB_TOPS)),$(BUILD_DIR)/$(tb)_v.png)
 V_NETLIST_JSON  := $(BUILD_DIR)/$(V_TOP)_v.json
 V_DIAGRAM_SVG   := $(BUILD_DIR)/$(V_TOP)_v.svg
@@ -196,7 +192,7 @@ endif
 	@echo "VHDL targets:"
 	@echo "  analyze     Parse and type-check the VHDL sources."
 	@echo "  elaborate   Elaborate every testbench in TB_TOPS."
-	@echo "  simulate    Run every testbench, emit one VCD per TB."
+	@echo "  simulate    Run every testbench, emit one FST per TB."
 	@echo "  diagram     Synthesise $(TOP) via yosys+ghdl, render SVG."
 	@echo "  waveform    Render one waveview SVG+PNG per simulation dump."
 ifneq ($(strip $(V_SRC_FILES)),)
@@ -238,21 +234,19 @@ $(foreach tb,$(TB_TOPS),$(eval $(call GHDL_ELAB_RULE,$(tb))))
 elaborate: $(foreach tb,$(TB_TOPS),elaborate-$(tb))
 
 # ---- Simulate (VHDL) -------------------------------------------------------
-# One waveform file per TB. Dumps VCD by default, FST when the TB is
-# listed in FST_TBS (GHDL handles both via --vcd= / --fst=).
+# One FST waveform file per TB.
 define GHDL_SIM_RULE
 $$(call tb_wave,$(1)): elaborate-$(1) | $$(BUILD_DIR)
 	$$(GHDL) -r $$(GHDL_SIM_FLAGS) $(1) --assert-level=$$(ASSERT_LEVEL) \
-	    $$(if $$(filter $(1),$$(FST_TBS)),--fst=$$@,--vcd=$$@) $$(SIM_STOPTIME)
+	    --fst=$$@ $$(SIM_STOPTIME)
 endef
 $(foreach tb,$(TB_TOPS),$(eval $(call GHDL_SIM_RULE,$(tb))))
 
-simulate: $(VCD_FILES)
+simulate: $(WAVE_FILES)
 
 # ---- Waveform render (VHDL) -----------------------------------------------
-# waveview reads both VCD and FST, so the rule just points at whichever
-# format the simulate step produced. waveview always emits an SVG;
-# --png adds the PNG alongside at the same stem. We route the SVG to
+# waveview reads FST natively. waveview always emits an SVG; --png adds
+# the PNG alongside at the same stem. We route the SVG to
 # build/<tb>.svg (a free vector-quality artifact picked up by the CI
 # gallery) and rely on --png to land build/<tb>.png.
 ifneq ($(strip $(SKIP_WAVEFORM)),)
@@ -303,32 +297,33 @@ endif
 ifneq ($(strip $(V_SRC_FILES)),)
 
 # ---- Simulate (Verilog) ---------------------------------------------------
-# One VVP binary, one VCD per testbench. The iverilog invocation per TB
-# supplies its own -DVCD_OUT so each `$dumpfile(`VCD_OUT)` lands in its
-# own build/<tb>_v.vcd file.
+# One VVP binary, one FST per testbench. The iverilog invocation per TB
+# supplies its own -DFST_OUT so each `$dumpfile(`FST_OUT)` lands in its
+# own build/<tb>_v.fst file. iverilog 13 switches its dump format from
+# VCD to FST when IVERILOG_DUMPER=fst is set in vvp's environment.
 define IVERILOG_RULE
 $$(BUILD_DIR)/$(1)_v.vvp: $$(V_SRC_FILES) $$(V_TB_FILES) | $$(BUILD_DIR)
 	$$(IVERILOG) -g2012 \
-	    -DVCD_OUT='"$(1)_v.vcd"' \
+	    -DFST_OUT='"$(1)_v.fst"' \
 	    $$(addprefix -D,$$(V_DEFINES)) \
 	    $$(addprefix -I,$$(V_INCDIRS)) \
 	    -s $(1) -o $$@ \
 	    $$(V_SRC_FILES) $$(V_TB_FILES)
 
-# Run vvp from build/ so the VCD path supplied via the VCD_OUT define
-# lands inside build/. Testbenches do `$dumpfile(`VCD_OUT)`, which
-# expands to "<tb>_v.vcd".
-$$(BUILD_DIR)/$(1)_v.vcd: $$(BUILD_DIR)/$(1)_v.vvp
-	cd $$(BUILD_DIR) && $$(VVP) -n $$(notdir $$<)
+# Run vvp from build/ so the FST path supplied via the FST_OUT define
+# lands inside build/. Testbenches do `$dumpfile(`FST_OUT)`, which
+# expands to "<tb>_v.fst".
+$$(BUILD_DIR)/$(1)_v.fst: $$(BUILD_DIR)/$(1)_v.vvp
+	cd $$(BUILD_DIR) && IVERILOG_DUMPER=fst $$(VVP) -n $$(notdir $$<)
 	@if [ ! -f $$@ ]; then \
 	    echo "ERROR: $(1) did not produce $$@" >&2; \
-	    echo "       (testbench should call \$$$$dumpfile(\`VCD_OUT))" >&2; \
+	    echo "       (testbench should call \$$$$dumpfile(\`FST_OUT))" >&2; \
 	    exit 1; \
 	fi
 endef
 $(foreach tb,$(V_TB_TOPS),$(eval $(call IVERILOG_RULE,$(tb))))
 
-simulate_v: $(V_VCD_FILES)
+simulate_v: $(V_WAVE_FILES)
 
 # ---- Waveform render (Verilog) --------------------------------------------
 ifneq ($(strip $(SKIP_V_WAVEFORM)),)

--- a/tools/simulator_writer/test/tb_simulator_writer.v
+++ b/tools/simulator_writer/test/tb_simulator_writer.v
@@ -15,7 +15,7 @@ module tb_simulator_writer;
     reg        sSimulationActive = 1'b1;
 
     // The DUT's `done` is referenced via `dut.done` throughout — no
-    // TB-level wire so the VCD does not expose the same signal twice.
+    // TB-level wire so the dump does not expose the same signal twice.
     tl_simulator_writer dut (
         .inClock  (clock),
         .outLines (outLines),
@@ -28,10 +28,10 @@ module tb_simulator_writer;
     // Dump TB-level signals plus the DUT signals that the VHDL side
     // also exposes. tl_simulator_writer keeps the v* state counters
     // as module-scope integers for yosys synthesis; listing signals
-    // explicitly here hides them from the VCD so the VHDL and Verilog
+    // explicitly here hides them from the FST so the VHDL and Verilog
     // waveforms carry the same set.
     initial begin
-        $dumpfile(`VCD_OUT);
+        $dumpfile(`FST_OUT);
         $dumpvars(1, tb_simulator_writer);
         $dumpvars(0, dut.inClock, dut.outLines, dut.done,
                      dut.sOutRow, dut.sCurrentBlank);

--- a/tools/simulator_writer/tl_simulator_writer.v
+++ b/tools/simulator_writer/tl_simulator_writer.v
@@ -28,7 +28,7 @@ module tl_simulator_writer #(
     reg        sCurrentBlank;
 
     // The VHDL twin keeps these as process *variables*; GHDL does not
-    // surface them in the VCD. They live at module scope here for
+    // surface them in the FST dump. They live at module scope here for
     // yosys compatibility (static locals inside a named always block
     // are not yet accepted by the yosys SV frontend) — the testbench
     // hides them via an explicit $dumpvars signal list so the two


### PR DESCRIPTION
## Summary

- `mk/common.mk`: GHDL always uses `--fst=`; iverilog runs `vvp` with `IVERILOG_DUMPER=fst` (the env-var hook iverilog 12 added), so both flows now produce FST natively. The bumped `hdltools:release` image ships iverilog 13.
- The per-TB `FST_TBS` opt-in is gone; everything is FST. `NO_WAVEFORM_TBS` (the orthogonal opt-out of the waveform render step) is unchanged.
- The Verilog macro `VCD_OUT` is renamed to `FST_OUT`; the make variable `VCD_FILES` becomes `WAVE_FILES`.
- 25 Verilog testbenches updated for the rename.
- 3 project Makefiles drop now-redundant `FST_TBS := …` lines.
- CI artifact glob `*.vcd` → `*.fst`; release-zip directory `release/vcd/` → `release/fst/`.
- README / CONTRIBUTING / top-level Makefile / `.gitignore` updated for the new flow.

FST is ~10-100x smaller than the equivalent VCD on long-window testbenches (e.g. `tb_counter_long` drops from ~650 MB VCD to ~27 MB FST). waveview reads FST natively, so rendered SVG/PNG output is unchanged.

## Test plan

- [x] Validated end-to-end against `ghcr.io/naelolaiz/hdltools:release` (iverilog 13.0): `basics/blink_led`, `building_blocks/random_generator`, `display/7segments/counter` all produce `.fst` for both VHDL and Verilog flows, and waveview renders SVG+PNG as before.
- [x] `NO_WAVEFORM_TBS` opt-outs still work — long testbenches dump FST but skip the render step.
- [x] CI matrix passes against the published image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)